### PR TITLE
Ensure service quote models load before extensions

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,6 +1,8 @@
 """Load all models for the CCN service quote module."""
 
 from . import (
+    service_quote,
+    site,
     add_package_wizard,
     patch_rubro_code,
     product,
@@ -15,6 +17,4 @@ from . import (
     rubro_flag,
     sale_order,
     service_package,
-    service_quote,
-    site,
 )


### PR DESCRIPTION
## Summary
- Import `service_quote` and `site` before dependent models so `ccn.service.quote.line` is registered early

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68be988f9c4c832183f1cdc3589382f4