### PR TITLE
Remove incompatible product_base_price field

### DIFF
--- a/models/quote_line_related.py
+++ b/models/quote_line_related.py
@@ -3,14 +3,6 @@ from odoo import models, fields
 class ServiceQuoteLineRelated(models.Model):
     _inherit = 'ccn.service.quote.line'
 
-    # Precio unitario desde el TEMPLATE para mantener tipo Monetary correcto
-    product_base_price = fields.Monetary(
-        string='Precio unitario',
-        related='product_id.product_tmpl_id.list_price',
-        currency_field='currency_id',
-        readonly=True,
-    )
-
     # Impuestos del producto (para mostrar en la lista)
     product_taxes_id = fields.Many2many(
         comodel_name='account.tax',


### PR DESCRIPTION
## Summary
- remove related `product_base_price` field that conflicted with `product.template.list_price`
- keep product tax relation only

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68be9cc0e5c883219a3e9086a8dba314