### PR TITLE
Limit service quote line columns to required fields

### DIFF
--- a/views/quote_line_list_inline.xml
+++ b/views/quote_line_list_inline.xml
@@ -24,11 +24,11 @@
           <!-- Tabulador -->
           <field name="tabulator_percent" string="Tabulador"/>
 
-          <!-- Impuestos (texto) -->
-          <field name="taxes_display" string="Detalle de impuestos" readonly="1" optional="show"/>
+          <!-- IVA -->
+          <field name="amount_tax" string="IVA" readonly="1"/>
 
           <!-- Subtotal -->
-          <field name="total_price" string="Subtotal final" readonly="1"/>
+          <field name="total_price" string="Subtotal" readonly="1"/>
 
           <!-- Metadatos ocultos -->
           <field name="quote_id" invisible="1"/>

--- a/views/quote_line_tree_inline.xml
+++ b/views/quote_line_tree_inline.xml
@@ -6,9 +6,6 @@
       <field name="model">ccn.service.quote.line</field>
       <field name="arch" type="xml">
         <list editable="bottom" string="Líneas del rubro">
-          <!-- Rubro (solo informativo aquí) -->
-          <field name="rubro_id" readonly="1" optional="hide"/>
-
           <!-- Producto: solo del rubro actual; sin abrir ficha -->
           <field name="product_id"
                  required="1"
@@ -29,11 +26,11 @@
           <!-- Tabulador (0/3/5/10 %) -->
           <field name="tabulator_percent" string="Tabulador"/>
 
-          <!-- Impuestos -->
-          <field name="tax_ids"/>
+          <!-- IVA -->
+          <field name="amount_tax" string="IVA" readonly="1"/>
 
-          <!-- Subtotal (sin impuestos) -->
-          <field name="price_subtotal" readonly="1"/>
+          <!-- Subtotal -->
+          <field name="total_price" string="Subtotal" readonly="1"/>
 
           <!-- Metadatos necesarios pero ocultos -->
           <field name="currency_id" invisible="1"/>

--- a/views/site_views.xml
+++ b/views/site_views.xml
@@ -36,10 +36,8 @@
                     <!-- Reemplaza base_price_unit por el campo real que sí tienes -->
                     <field name="price_unit_final" string="Precio Unitario"/>
                     <field name="tabulator_percent" string="Tabulador"/>
-                    <!-- Muestra subtotal con tu campo existente -->
-                    <field name="total_price" string="Subtotal final" readonly="1"/>
-                    <!-- Si ya añadiste tax_ids, puedes insertarlo aquí entre Tabulador y Subtotal -->
-                    <!-- <field name="tax_ids" widget="many2many_tags" string="Impuestos aplicables"/> -->
+                    <field name="amount_tax" string="IVA" readonly="1"/>
+                    <field name="total_price" string="Subtotal" readonly="1"/>
                   </list>
                 </field>
               </page>


### PR DESCRIPTION
## Summary
- Show only the required columns in service quote line views: product/service, quantity, unit price, tabulator, IVA and subtotal
- Align site form line list with the same column set and labels
- Update alternate tree view for quote lines to use IVA and subtotal columns only

## Testing
- `xmllint --noout views/quote_line_list_inline.xml views/site_views.xml views/quote_line_tree_inline.xml`

------
https://chatgpt.com/codex/tasks/task_e_68bea09eadb483218e54c5c5132ca7ce