### PR TITLE
Hide metadata columns in quote line inline views

### DIFF
--- a/views/quote_line_list_inline.xml
+++ b/views/quote_line_list_inline.xml
@@ -7,7 +7,7 @@
       <field name="type">list</field>
       <field name="arch" type="xml">
         <list editable="bottom" string="Líneas del rubro">
-          <field name="rubro_id" invisible="1"/>
+          <field name="rubro_id" invisible="1" column_invisible="1"/>
 
           <!-- Producto/Servicio del rubro (filtro por rubro del template) -->
           <field name="product_id" required="1"
@@ -31,10 +31,10 @@
           <field name="total_price" string="Subtotal" readonly="1"/>
 
           <!-- Metadatos ocultos -->
-          <field name="quote_id" invisible="1"/>
-          <field name="site_id" invisible="1"/>
-          <field name="type" invisible="1"/>
-          <field name="currency_id" invisible="1"/>
+          <field name="quote_id" invisible="1" column_invisible="1"/>
+          <field name="site_id" invisible="1" column_invisible="1"/>
+          <field name="type" invisible="1" column_invisible="1"/>
+          <field name="currency_id" invisible="1" column_invisible="1"/>
         </list>
       </field>
     </record>

--- a/views/quote_line_tree_inline.xml
+++ b/views/quote_line_tree_inline.xml
@@ -33,11 +33,11 @@
           <field name="total_price" string="Subtotal" readonly="1"/>
 
           <!-- Metadatos necesarios pero ocultos -->
-          <field name="currency_id" invisible="1"/>
-          <field name="quote_id" invisible="1"/>
-          <field name="site_id" invisible="1"/>
-          <field name="type" invisible="1"/>
-          <field name="rubro_code" invisible="1"/>
+          <field name="currency_id" invisible="1" column_invisible="1"/>
+          <field name="quote_id" invisible="1" column_invisible="1"/>
+          <field name="site_id" invisible="1" column_invisible="1"/>
+          <field name="type" invisible="1" column_invisible="1"/>
+          <field name="rubro_code" invisible="1" column_invisible="1"/>
         </list>
       </field>
     </record>


### PR DESCRIPTION
## Summary
- add column_invisible to rubro, site, type and currency fields in quote line list
- hide metadata columns in inline tree view

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bea2edbf0c8321a93be1c515d3302f