### PR TITLE
Fix presentation mode and remove unused selector

### DIFF
--- a/views/quote_views.xml
+++ b/views/quote_views.xml
@@ -10,16 +10,12 @@
         <form string="CCN Service Quote">
           <sheet>
 
-            <!-- Cabecera sin repetir "Sitio" -->
+            <!-- Cabecera -->
             <group>
-              <group>
-                <field name="name"/>
-              </group>
-              <group string="Modo de presentación">
-                <field name="current_site_id" domain="[('quote_id','=', id)]"/>
-                <field name="current_service_type"/>
-                <field name="current_type"/>
-              </group>
+              <field name="name" colspan="2"/>
+              <field name="current_site_id" domain="[('quote_id','=', id)]" colspan="2"/>
+              <field name="current_service_type" colspan="2"/>
+              <field name="display_mode" colspan="2"/>
             </group>
 
             <!-- Tabs por rubro (edición inline) -->


### PR DESCRIPTION
## Summary
- add missing `display_mode` field to service quote with options *Acumulado por rubro*, *Acumulado General* and *Itemizado*
- align quote header to the left and remove misleading site selector
- auto-derive `current_type` from `current_service_type`

## Testing
- `python -m py_compile models/service_quote.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68beb124dc94832187ff6405dd81a13e