### PR TITLE
Restrict product selection to rubros and rename tab

### DIFF
--- a/views/product_template_ccn.xml
+++ b/views/product_template_ccn.xml
@@ -7,7 +7,7 @@
       <field name="inherit_id" ref="product.product_template_only_form_view"/>
       <field name="arch" type="xml">
         <xpath expr="//sheet/notebook" position="inside">
-          <page string="CCN Service">
+          <page string="Rubro CCN">
             <group>
               <field name="ccn_rubro_ids" widget="many2many_tags"
                      options="{'no_create_edit': True}"

--- a/views/quote_line_domain.xml
+++ b/views/quote_line_domain.xml
@@ -17,7 +17,7 @@
 
               <!-- Filtra productos (placeholder + rubro) -->
               <field name="product_id"
-                     options="{'no_open': True}"
+                     options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"
                      domain="[('product_tmpl_id.ccn_exclude_from_quote','=',False),
                               ('product_tmpl_id.ccn_rubro_ids','in',[rubro_id])]"/>
 
@@ -33,7 +33,7 @@
               <group>
                 <field name="rubro_id" domain="[('internal_only','=',False)]"/>
                 <field name="product_id"
-                       options="{'no_open': True}"
+                       options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"
                        domain="[('product_tmpl_id.ccn_exclude_from_quote','=',False),
                                 ('product_tmpl_id.ccn_rubro_ids','in',[rubro_id])]"/>
                 <field name="quantity"/>

--- a/views/quote_line_list_inline.xml
+++ b/views/quote_line_list_inline.xml
@@ -13,7 +13,7 @@
           <field name="product_id" required="1"
                  domain="[('product_tmpl_id.ccn_exclude_from_quote','=',False),
                           ('product_tmpl_id.ccn_rubro_ids','in',[rubro_id])]"
-                 options="{'no_open': True}"/>
+                 options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"/>
 
           <!-- Cantidad -->
           <field name="quantity"/>


### PR DESCRIPTION
## Summary
- Rename product template tab from CCN Service to Rubro CCN
- Prevent creating new products in quote line selectors so only items with the chosen rubro can be selected

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68beb3fdee448321a4218c952315ff79