### PR TITLE
fix: include rubro code when filtering products

### DIFF
--- a/views/quote_line_domain.xml
+++ b/views/quote_line_domain.xml
@@ -19,6 +19,8 @@
               <field name="product_id"
                      options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"
                      domain="[('product_tmpl_id.ccn_exclude_from_quote','=',False),
+                              '|',
+                              ('product_tmpl_id.ccn_rubro_ids.code','=', context.get('ctx_rubro_code')),
                               ('product_tmpl_id.ccn_rubro_ids','in',[rubro_id])]"/>
 
               <field name="quantity"/>
@@ -35,6 +37,8 @@
                 <field name="product_id"
                        options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"
                        domain="[('product_tmpl_id.ccn_exclude_from_quote','=',False),
+                                '|',
+                                ('product_tmpl_id.ccn_rubro_ids.code','=', context.get('ctx_rubro_code')),
                                 ('product_tmpl_id.ccn_rubro_ids','in',[rubro_id])]"/>
                 <field name="quantity"/>
                 <field name="tabulator_percent"/>

--- a/views/quote_line_list_inline.xml
+++ b/views/quote_line_list_inline.xml
@@ -12,6 +12,8 @@
           <!-- Producto/Servicio del rubro (filtro por rubro del template) -->
           <field name="product_id" required="1"
                  domain="[('product_tmpl_id.ccn_exclude_from_quote','=',False),
+                          '|',
+                          ('product_tmpl_id.ccn_rubro_ids.code','=', context.get('ctx_rubro_code')),
                           ('product_tmpl_id.ccn_rubro_ids','in',[rubro_id])]"
                  options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"/>
 


### PR DESCRIPTION
## Summary
- ensure product selection also matches rubro code for service quotes
- prevent new products tagged with Mano de Obra from being filtered out

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68beb6231f3c8321bcc6ab483ed86551