### PR TITLE
fix: honor sale_ok in quote product domains

### DIFF
--- a/views/quote_line_domain.xml
+++ b/views/quote_line_domain.xml
@@ -18,7 +18,8 @@
               <!-- Filtra productos (placeholder + rubro) -->
               <field name="product_id"
                      options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"
-                     domain="[('product_tmpl_id.ccn_exclude_from_quote','=',False),
+                     domain="[('sale_ok','=',True),
+                              ('product_tmpl_id.ccn_exclude_from_quote','=',False),
                               '|',
                               ('product_tmpl_id.ccn_rubro_ids.code','=', context.get('ctx_rubro_code')),
                               ('product_tmpl_id.ccn_rubro_ids','in',[rubro_id])]"/>
@@ -36,7 +37,8 @@
                 <field name="rubro_id" domain="[('internal_only','=',False)]"/>
                 <field name="product_id"
                        options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"
-                       domain="[('product_tmpl_id.ccn_exclude_from_quote','=',False),
+                       domain="[('sale_ok','=',True),
+                                ('product_tmpl_id.ccn_exclude_from_quote','=',False),
                                 '|',
                                 ('product_tmpl_id.ccn_rubro_ids.code','=', context.get('ctx_rubro_code')),
                                 ('product_tmpl_id.ccn_rubro_ids','in',[rubro_id])]"/>

--- a/views/quote_line_list_inline.xml
+++ b/views/quote_line_list_inline.xml
@@ -11,7 +11,8 @@
 
           <!-- Producto/Servicio del rubro (filtro por rubro del template) -->
           <field name="product_id" required="1"
-                 domain="[('product_tmpl_id.ccn_exclude_from_quote','=',False),
+                 domain="[('sale_ok','=',True),
+                          ('product_tmpl_id.ccn_exclude_from_quote','=',False),
                           '|',
                           ('product_tmpl_id.ccn_rubro_ids.code','=', context.get('ctx_rubro_code')),
                           ('product_tmpl_id.ccn_rubro_ids','in',[rubro_id])]"

--- a/views/quote_line_tree_inline.xml
+++ b/views/quote_line_tree_inline.xml
@@ -11,6 +11,7 @@
                  required="1"
                  options="{'no_open': True, 'no_create_edit': True}"
                  domain="[
+                   ('sale_ok','=',True),
                    ('product_tmpl_id.ccn_exclude_from_quote','=',False),
                    '|',
                    ('product_tmpl_id.ccn_rubro_ids.code','=', context.get('ctx_rubro_code')),


### PR DESCRIPTION
## Summary
- ensure product selectors in quote lines only show items with `sale_ok` and matching rubro

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `xmllint --noout views/quote_line_domain.xml views/quote_line_list_inline.xml views/quote_line_tree_inline.xml`


------
https://chatgpt.com/codex/tasks/task_e_68beb9c4eaac83218b89bbb8305be563