### PR TITLE
fix: relax quote product filter

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "CCN Service Quote",
     "summary": "Wizard para cotizar servicios CCN",
-    "version": "18.0.9.0.42",
+    "version": "18.0.9.0.43",
     "author": "Witann Technologies",
     "license": "LGPL-3",
     "category": "Sales/Sales",

--- a/views/quote_line_domain.xml
+++ b/views/quote_line_domain.xml
@@ -18,8 +18,7 @@
               <!-- Filtra productos (placeholder + rubro) -->
               <field name="product_id"
                      options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"
-                     domain="[('sale_ok','=',True),
-                              ('product_tmpl_id.ccn_exclude_from_quote','=',False),
+                     domain="[('product_tmpl_id.ccn_exclude_from_quote','=',False),
                               '|',
                               ('product_tmpl_id.ccn_rubro_ids.code','=', context.get('ctx_rubro_code')),
                               ('product_tmpl_id.ccn_rubro_ids','in',[rubro_id])]"/>
@@ -37,8 +36,7 @@
                 <field name="rubro_id" domain="[('internal_only','=',False)]"/>
                 <field name="product_id"
                        options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"
-                       domain="[('sale_ok','=',True),
-                                ('product_tmpl_id.ccn_exclude_from_quote','=',False),
+                       domain="[('product_tmpl_id.ccn_exclude_from_quote','=',False),
                                 '|',
                                 ('product_tmpl_id.ccn_rubro_ids.code','=', context.get('ctx_rubro_code')),
                                 ('product_tmpl_id.ccn_rubro_ids','in',[rubro_id])]"/>

--- a/views/quote_line_list_inline.xml
+++ b/views/quote_line_list_inline.xml
@@ -11,8 +11,7 @@
 
           <!-- Producto/Servicio del rubro (filtro por rubro del template) -->
           <field name="product_id" required="1"
-                 domain="[('sale_ok','=',True),
-                          ('product_tmpl_id.ccn_exclude_from_quote','=',False),
+                 domain="[('product_tmpl_id.ccn_exclude_from_quote','=',False),
                           '|',
                           ('product_tmpl_id.ccn_rubro_ids.code','=', context.get('ctx_rubro_code')),
                           ('product_tmpl_id.ccn_rubro_ids','in',[rubro_id])]"

--- a/views/quote_line_tree_inline.xml
+++ b/views/quote_line_tree_inline.xml
@@ -11,7 +11,6 @@
                  required="1"
                  options="{'no_open': True, 'no_create_edit': True}"
                  domain="[
-                   ('sale_ok','=',True),
                    ('product_tmpl_id.ccn_exclude_from_quote','=',False),
                    '|',
                    ('product_tmpl_id.ccn_rubro_ids.code','=', context.get('ctx_rubro_code')),


### PR DESCRIPTION
## Summary
- allow selecting products regardless of `sale_ok` in quote lines
- bump module version to 18.0.9.0.43

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `xmllint --noout views/quote_line_domain.xml views/quote_line_list_inline.xml views/quote_line_tree_inline.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bebcec173c8321951401b10006dfbf