### PR TITLE
Disable product creation from service quote lines

### DIFF
--- a/views/quote_line_tree_inline.xml
+++ b/views/quote_line_tree_inline.xml
@@ -9,7 +9,7 @@
           <!-- Producto: solo del rubro actual; sin abrir ficha -->
           <field name="product_id"
                  required="1"
-                 options="{'no_open': True, 'no_create_edit': True}"
+                 options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"
                  domain="[
                    ('product_tmpl_id.ccn_exclude_from_quote','=',False),
                    '|',

--- a/views/site_views.xml
+++ b/views/site_views.xml
@@ -30,9 +30,9 @@
             <notebook>
               <page string="Líneas">
                 <field name="line_ids" mode="list" context="{'list_view_ref': 'ccn_service_quote.ccn_view_quote_line_list_inline'}">
-                  <list editable="bottom" string="Líneas del sitio">
-                    <field name="product_id" options="{'no_open': True, 'no_create_edit': True}"/>
-                    <field name="quantity"/>
+                    <list editable="bottom" string="Líneas del sitio">
+                      <field name="product_id" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"/>
+                      <field name="quantity"/>
                     <!-- Reemplaza base_price_unit por el campo real que sí tienes -->
                     <field name="price_unit_final" string="Precio Unitario"/>
                     <field name="tabulator_percent" string="Tabulador"/>
@@ -113,7 +113,7 @@
                           <field name="line_ids" mode="list,form">
                             <list editable="bottom">
                               <field name="rubro_id"/>
-                              <field name="product_id"/>
+                              <field name="product_id" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"/>
                               <field name="quantity"/>
                               <field name="base_price_unit"/>
                               <field name="tabulator_percent"/>
@@ -123,7 +123,7 @@
                             <form string="Línea de sitio">
                               <group>
                                 <field name="rubro_id"/>
-                                <field name="product_id"/>
+                                <field name="product_id" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"/>
                                 <field name="quantity"/>
                                 <field name="base_price_unit"/>
                                 <field name="tabulator_percent"/>
@@ -181,9 +181,9 @@
                       <page string="Líneas">
                         <field name="line_ids" mode="list,form">
                           <list editable="bottom">
-                            <field name="rubro_id"/>
-                            <field name="product_id"/>
-                            <field name="quantity"/>
+                                  <field name="rubro_id"/>
+                                  <field name="product_id" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"/>
+                                  <field name="quantity"/>
                             <field name="base_price_unit"/>
                             <field name="tabulator_percent"/>
                             <field name="price_unit_final" readonly="1"/>
@@ -191,9 +191,9 @@
                           </list>
                           <form string="Línea de sitio">
                             <group>
-                              <field name="rubro_id"/>
-                              <field name="product_id"/>
-                              <field name="quantity"/>
+                                <field name="rubro_id"/>
+                                <field name="product_id" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"/>
+                                <field name="quantity"/>
                               <field name="base_price_unit"/>
                               <field name="tabulator_percent"/>
                               <field name="price_unit_final" readonly="1"/>


### PR DESCRIPTION
## Summary
- prevent creating products from service quote line dropdowns
- restrict site line product selection to existing products only

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bec8a20bd483218665499ff7956b77