### PR TITLE
fix: allow product selection by rubro

### DIFF
--- a/views/quote_line_domain.xml
+++ b/views/quote_line_domain.xml
@@ -19,9 +19,7 @@
               <field name="product_id"
                      options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"
                      domain="[('product_tmpl_id.ccn_exclude_from_quote','=',False),
-                              '|',
-                              ('product_tmpl_id.ccn_rubro_ids.code','=', context.get('ctx_rubro_code')),
-                              ('product_tmpl_id.ccn_rubro_ids','in',[rubro_id])]"/>
+                              ('product_tmpl_id.ccn_rubro_ids.code','in',[context.get('ctx_rubro_code'), rubro_code])]"/>
 
               <field name="quantity"/>
               <field name="tabulator_percent"/>
@@ -37,9 +35,7 @@
                 <field name="product_id"
                        options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"
                        domain="[('product_tmpl_id.ccn_exclude_from_quote','=',False),
-                                '|',
-                                ('product_tmpl_id.ccn_rubro_ids.code','=', context.get('ctx_rubro_code')),
-                                ('product_tmpl_id.ccn_rubro_ids','in',[rubro_id])]"/>
+                                ('product_tmpl_id.ccn_rubro_ids.code','in',[context.get('ctx_rubro_code'), rubro_code])]"/>
                 <field name="quantity"/>
                 <field name="tabulator_percent"/>
                 <field name="base_price_unit"/>

--- a/views/quote_line_list_inline.xml
+++ b/views/quote_line_list_inline.xml
@@ -12,9 +12,7 @@
           <!-- Producto/Servicio del rubro (filtro por rubro del template) -->
           <field name="product_id" required="1"
                  domain="[('product_tmpl_id.ccn_exclude_from_quote','=',False),
-                          '|',
-                          ('product_tmpl_id.ccn_rubro_ids.code','=', context.get('ctx_rubro_code')),
-                          ('product_tmpl_id.ccn_rubro_ids','in',[rubro_id])]"
+                          ('product_tmpl_id.ccn_rubro_ids.code','in',[context.get('ctx_rubro_code'), rubro_code])]"
                  options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"/>
 
           <!-- Cantidad -->

--- a/views/quote_line_tree_inline.xml
+++ b/views/quote_line_tree_inline.xml
@@ -12,9 +12,7 @@
                  options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"
                  domain="[
                    ('product_tmpl_id.ccn_exclude_from_quote','=',False),
-                   '|',
-                   ('product_tmpl_id.ccn_rubro_ids.code','=', context.get('ctx_rubro_code')),
-                   ('product_tmpl_id.ccn_rubro_ids','in',[rubro_id])
+                   ('product_tmpl_id.ccn_rubro_ids.code','in',[context.get('ctx_rubro_code'), rubro_code])
                  ]"/>
 
           <!-- Cantidad -->


### PR DESCRIPTION
## Summary
- allow quote product selector to use rubro code when filtering products

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68becb1c429c832199817601eb1b7d70