### PR TITLE
Enable inline site management on quote form

### DIFF
--- a/views/cleanup_disable_legacy_views.xml
+++ b/views/cleanup_disable_legacy_views.xml
@@ -16,18 +16,5 @@
       </field>
     </record>
 
-    <!-- Desactiva la variante que añadía 'Sitios / Resumen Global' -->
-    <record id="ccn_view_quote_form_sites" model="ir.ui.view">
-      <field name="name">ccn.quote.form.sites (DISABLED)</field>
-      <field name="model">ccn.service.quote</field>
-      <field name="inherit_id" ref="ccn_service_quote.ccn_view_quote_form"/>
-      <field name="active">False</field>
-      <field name="arch" type="xml">
-        <xpath expr="//sheet" position="inside">
-          <separator string="(legacy sites disabled)"/>
-        </xpath>
-      </field>
-    </record>
-
   </data>
 </odoo>

--- a/views/site_views.xml
+++ b/views/site_views.xml
@@ -72,12 +72,28 @@
       <field name="inherit_id" ref="ccn_service_quote.ccn_view_quote_form"/>
       <field name="arch" type="xml">
 
-        <!-- 1) Debajo de los grupos superiores, inserta el selector del sitio actual -->
+        <!-- Elimina el selector original de sitio del encabezado -->
+        <xpath expr="//form/sheet/group/field[@name='current_site_id']" position="replace"/>
+
+        <!-- Inserta selector y lista de sitios directamente en la pantalla principal -->
         <xpath expr="//form/sheet/group" position="after">
-          <group string="Sitio en edición">
-            <field name="current_site_id"
-                   domain="[('quote_id','=', id)]"
-                   context="{'default_quote_id': id}"/>
+          <group>
+            <group string="Sitio en edición">
+              <field name="current_site_id"
+                     domain="[('quote_id','=', id)]"
+                     context="{'default_quote_id': id}"
+                     options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"/>
+            </group>
+            <group string="Sitios">
+              <field name="site_ids" mode="list"
+                     context="{'default_quote_id': id}"
+                     options="{'no_open': True}">
+                <list editable="bottom">
+                  <field name="sequence"/>
+                  <field name="name"/>
+                </list>
+              </field>
+            </group>
           </group>
         </xpath>
 
@@ -87,7 +103,7 @@
 
             <!-- A) Sitio actual (indicadores ARRIBA y líneas ABAJO, embebiendo el form del sitio) -->
             <page string="Sitio actual">
-              <field name="current_site_id" options="{'no_create_edit': True}">
+              <field name="current_site_id" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}">
                 <!-- Reutilizamos el form del sitio -->
                 <form position="replace">
                   <form string="Sitio">
@@ -149,73 +165,6 @@
                       </notebook>
                     </sheet>
                   </form>
-                </form>
-              </field>
-            </page>
-
-            <!-- B) Gestión de sitios (lista mínima; al abrir se ve el form con indicadores arriba) -->
-            <page string="Sitios">
-              <field name="site_ids" mode="list,form">
-                <list editable="bottom">
-                  <field name="sequence"/>
-                  <field name="name"/>
-                </list>
-                <form string="Sitio">
-                  <sheet>
-                    <group>
-                      <group>
-                        <field name="name"/>
-                        <field name="quote_id" options="{'no_open': True}"/>
-                        <field name="sequence"/>
-                      </group>
-                      <group string="Parámetros">
-                        <field name="headcount"/>
-                        <field name="admin_percent"/>
-                        <field name="utility_percent"/>
-                        <field name="financial_percent"/>
-                        <field name="transporte_rate"/>
-                        <field name="bienestar_rate"/>
-                      </group>
-                    </group>
-                    <notebook>
-                      <page string="Líneas">
-                        <field name="line_ids" mode="list,form">
-                          <list editable="bottom">
-                                  <field name="rubro_id"/>
-                                  <field name="product_id" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"/>
-                                  <field name="quantity"/>
-                            <field name="base_price_unit"/>
-                            <field name="tabulator_percent"/>
-                            <field name="price_unit_final" readonly="1"/>
-                            <field name="total_price" readonly="1"/>
-                          </list>
-                          <form string="Línea de sitio">
-                            <group>
-                                <field name="rubro_id"/>
-                                <field name="product_id" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"/>
-                                <field name="quantity"/>
-                              <field name="base_price_unit"/>
-                              <field name="tabulator_percent"/>
-                              <field name="price_unit_final" readonly="1"/>
-                              <field name="total_price" readonly="1"/>
-                            </group>
-                          </form>
-                        </field>
-                      </page>
-                      <page string="Resumen del sitio">
-                        <group>
-                          <field name="subtotal1" readonly="1"/>
-                          <field name="admin_amt" readonly="1"/>
-                          <field name="util_amt" readonly="1"/>
-                          <field name="subtotal2" readonly="1"/>
-                          <field name="transporte_amt" readonly="1"/>
-                          <field name="bienestar_amt" readonly="1"/>
-                          <field name="financial_amt" readonly="1"/>
-                          <field name="total_monthly" readonly="1"/>
-                        </group>
-                      </page>
-                    </notebook>
-                  </sheet>
                 </form>
               </field>
             </page>


### PR DESCRIPTION
## Summary
- Show current site selector and site list directly on the quote form
- Allow editing the active site inline and remove legacy site view disablement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bed577b570832194d33364fa68ae35