### PR TITLE
Elimina diálogo de creación de sitio

### DIFF
--- a/views/quote_views.xml
+++ b/views/quote_views.xml
@@ -13,7 +13,7 @@
             <!-- Cabecera -->
             <group>
               <field name="name" colspan="2"/>
-              <field name="current_site_id" domain="[('quote_id','=', id)]" colspan="2"/>
+              <field name="current_site_id" domain="[('quote_id','=', id)]" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}" colspan="2"/>
               <field name="current_service_type" colspan="2"/>
               <field name="display_mode" colspan="2"/>
             </group>


### PR DESCRIPTION
## Summary
- Evita que se abra el diálogo de creación de sitios al seleccionar el sitio actual en la cotización.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68beff416da48321b176bf10955e0583