### PR TITLE
Enable site creation and editing

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "CCN Service Quote",
     "summary": "Wizard para cotizar servicios CCN",
-    "version": "18.0.9.1.5",
+    "version": "18.0.9.1.6",
     "author": "Witann Technologies",
     "license": "LGPL-3",
     "category": "Sales/Sales",
@@ -21,6 +21,7 @@
         'data/ccn_rubros.xml',
         'views/site_views.xml',
         'views/cleanup_disable_legacy_views.xml',
+        'views/quote_site_fix.xml',
     ],
     "installable": True,
     "application": True,

--- a/views/quote_site_fix.xml
+++ b/views/quote_site_fix.xml
@@ -3,22 +3,13 @@
     <record id="view_ccn_service_quote_form_site_fix" model="ir.ui.view">
       <field name="name">ccn.service.quote.form.site.fix</field>
       <field name="model">ccn.service.quote</field>
-      <!-- ⚠️ Sustituye por el XMLID real de tu vista base -->
       <field name="inherit_id" ref="ccn_service_quote.ccn_view_quote_form"/>
       <field name="arch" type="xml">
-        <!-- A) opción 'attributes': borra options/readonly y agrega context -->
-        <xpath expr="//field[@name='current_site_id']" position="attributes">
-          <attribute name="options"/>
-          <attribute name="readonly"/>
-          <attribute name="context">{'default_quote_id': id}</attribute>
+        <xpath expr="//field[@name='current_site_id']" position="replace">
+          <field name="current_site_id"
+                 domain="[('quote_id','=', id)]"
+                 context="{'default_quote_id': id}"/>
         </xpath>
-        <!-- B) Si prefieres, reemplaza el nodo completo:
-        <xpath expr=\"//field[@name='current_site_id']\" position=\"replace\">
-          <field name=\"current_site_id\"
-                 domain=\"[('quote_id','=', id)]\"
-                 context=\"{'default_quote_id': id}\"/>
-        </xpath>
-        -->
       </field>
     </record>
   </data>


### PR DESCRIPTION
## Summary
- ensure quote form's current site field allows creating and selecting sites
- load site fix view from manifest

## Testing
- `python -m py_compile __manifest__.py`
- `xmllint --noout views/quote_site_fix.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bf202aaacc8321a0d912548e1d7097