### PR TITLE
feat(ui): control tab progression and color

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -23,6 +23,12 @@
         'views/cleanup_disable_legacy_views.xml',
         'views/quote_site_fix.xml',
     ],
+    "assets": {
+        "web.assets_backend": [
+            "ccn_service_quote/static/src/js/quote_notebook.js",
+            "ccn_service_quote/static/src/scss/quote_notebook.scss",
+        ],
+    },
     "installable": True,
     "application": True,
     "auto_install": False,

--- a/static/src/js/quote_notebook.js
+++ b/static/src/js/quote_notebook.js
@@ -1,0 +1,63 @@
+/** @odoo-module **/
+
+import { patch } from "@web/core/utils/patch";
+import { FormController } from "@web/views/form/form_controller";
+import { _t } from "@web/core/l10n/translation";
+
+function initQuoteTabs(controller) {
+    if (controller.model?.name !== "ccn.service.quote") {
+        return;
+    }
+    const notebook = controller.el.querySelector("div.o_notebook");
+    if (!notebook) return;
+    const tabs = notebook.querySelectorAll(":scope > ul.nav-tabs > li");
+    tabs.forEach((li, index) => {
+        li.classList.add("ccn-tab-angle");
+        const a = li.querySelector("a");
+        const pane = notebook.querySelector(a.getAttribute("href"));
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "btn btn-secondary ccn-skip";
+        btn.textContent = _t("No Aplica");
+        pane.prepend(btn);
+        btn.addEventListener("click", () => {
+            li.classList.remove("ccn-tab-empty");
+            li.classList.add("ccn-tab-skip");
+        });
+        if (!pane.querySelector("table tbody tr")) {
+            li.classList.add("ccn-tab-empty");
+        } else {
+            li.classList.add("ccn-tab-complete");
+        }
+        li.addEventListener("click", (ev) => {
+            const prev = Array.from(tabs).slice(0, index);
+            const ok = prev.every((p) => p.classList.contains("ccn-tab-complete") || p.classList.contains("ccn-tab-skip"));
+            if (!ok) {
+                ev.preventDefault();
+                ev.stopPropagation();
+                controller.displayNotification({
+                    title: _t("Atención"),
+                    message: _t("Completa el paso anterior."),
+                    type: "warning",
+                });
+            }
+        }, true);
+        pane.addEventListener("DOMSubtreeModified", () => {
+            if (pane.querySelector("table tbody tr")) {
+                li.classList.remove("ccn-tab-empty");
+                li.classList.add("ccn-tab-complete");
+            }
+        });
+    });
+}
+
+patch(FormController.prototype, "ccn_quote_notebook", {
+    async onMounted() {
+        await this._super(...arguments);
+        initQuoteTabs(this);
+    },
+    async onWillUpdate() {
+        await this._super(...arguments);
+        initQuoteTabs(this);
+    },
+});

--- a/static/src/scss/quote_notebook.scss
+++ b/static/src/scss/quote_notebook.scss
@@ -1,0 +1,32 @@
+.ccn-tab-angle {
+    position: relative;
+}
+
+.ccn-tab-angle a {
+    border-top-right-radius: 0 !important;
+    padding-right: 1.5rem;
+}
+
+.ccn-tab-angle::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: -15px;
+    width: 0;
+    height: 0;
+    border-top: 15px solid transparent;
+    border-bottom: 15px solid transparent;
+    border-left: 15px solid #ddd;
+}
+
+.ccn-tab-empty > a {
+    background-color: #ffdddd !important;
+}
+
+.ccn-tab-skip > a {
+    background-color: #fff4c2 !important;
+}
+
+.ccn-tab-complete > a {
+    background-color: #d4f9d4 !important;
+}


### PR DESCRIPTION
## Summary
- colorize quote tabs when empty or skipped
- enforce sequential navigation in quote notebooks

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bf229feaac8321b10979b9ba6cc9d6