### PR TITLE
Fix quote tabs initialization to avoid blank page

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "CCN Service Quote",
     "summary": "Wizard para cotizar servicios CCN",
-    "version": "18.0.9.1.7",
+    "version": "18.0.9.1.8",
     "author": "Witann Technologies",
     "license": "LGPL-3",
     "category": "Sales/Sales",


### PR DESCRIPTION
## Summary
- Avoid using optional chaining and switch to MutationObserver when initializing quote tabs
- Bump module version to 18.0.9.1.8

## Testing
- `node --check static/src/js/quote_notebook.js`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bf245ed14883219d0c18332fee47fa