### PR TITLE
Fix site creation list to avoid dialog

### DIFF
--- a/views/site_views.xml
+++ b/views/site_views.xml
@@ -80,7 +80,8 @@
             </group>
             <group string="Sitios">
               <field name="site_ids" mode="list"
-                     context="{'default_quote_id': id}">
+                     context="{'default_quote_id': id}"
+                     options="{'no_open': True, 'no_create_edit': True}">
                 <list editable="bottom">
                   <field name="sequence"/>
                   <field name="name"/>


### PR DESCRIPTION
## Summary
- prevent site list from opening create/edit dialog

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bf2867fef08321a49f9ccb635c4765