### PR TITLE
Remove duplicate quote_site_fix view from manifest

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -25,7 +25,6 @@
         'data/ccn_rubros.xml',
         'views/site_views.xml',
         'views/cleanup_disable_legacy_views.xml',
-        'views/quote_site_fix.xml',
     ],
     "assets": {
         "web.assets_backend": [


### PR DESCRIPTION
## Summary
- Avoid loading `quote_site_fix.xml` twice by removing the duplicated entry in `__manifest__.py`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf619ebbb0832180702d06fa455d70