### PR TITLE
Style chevron tabs with left angles

### DIFF
--- a/static/src/scss/quote_tabs.scss
+++ b/static/src/scss/quote_tabs.scss
@@ -8,7 +8,32 @@
   border: 1px solid #d9e1ea;
   clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 50%, calc(100% - 16px) 100%, 0 100%);
 }
-.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link.ccn-status-empty   { background:#e74c3c; color:#fff; border-color:#c0392b; }
-.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link.ccn-status-ack     { background:#f1c40f; color:#4a3d00; border-color:#d4ac0d; }
-.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link.ccn-status-filled  { background:#2ecc71; color:#fff; border-color:#27ae60; }
-.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link:hover { filter: brightness(0.97); }
+
+.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link:not(:first-child) {
+  margin-left: -16px;
+  padding-left: 2.25rem;
+  clip-path: polygon(16px 0, calc(100% - 16px) 0, 100% 50%, calc(100% - 16px) 100%, 16px 100%, 0 50%);
+}
+
+.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link.ccn-status-empty {
+  background: #e74c3c !important;
+  color: #fff !important;
+  border-color: #c0392b !important;
+}
+
+.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link.ccn-status-ack {
+  background: #f1c40f !important;
+  color: #4a3d00 !important;
+  border-color: #d4ac0d !important;
+}
+
+.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link.ccn-status-filled {
+  background: #2ecc71 !important;
+  color: #fff !important;
+  border-color: #27ae60 !important;
+}
+
+.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link:hover {
+  filter: brightness(0.97);
+}
+


### PR DESCRIPTION
## Summary
- Angle the left side of quote tabs after the first entry to reduce wasted space
- Force tab status colors to display by marking color rules as `!important`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bf637c990883219512207c9b2f3fd8