### PR TITLE
Fix asset path for tab badges

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "CCN Service Quote",
     "summary": "Wizard para cotizar servicios CCN",
-    "version": "18.0.9.1.23",
+    "version": "18.0.9.1.24",
     "author": "Witann Technologies",
     "license": "LGPL-3",
     "category": "Sales/Sales",
@@ -28,7 +28,7 @@
     ],
     "assets": {
         "web.assets_backend": [
-            "ccn_service_quote/static/src/js/quote_tab_badges.js",
+            "ccn_service_quote/static/src/js/quote_tabs_badges.js",
             "ccn_service_quote/static/src/scss/quote_tabs.scss",
         ]
     },


### PR DESCRIPTION
## Summary
- fix asset path for quote tab badges JS
- bump module version to 18.0.9.1.24

## Testing
- `python -m py_compile __manifest__.py`
- `node --check static/src/js/quote_tabs_badges.js` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bf652d569c8321af2fa22bf858ba44