### PR TITLE
Fix tab badge service initialization

### DIFF
--- a/static/src/js/quote_tabs_badges.js
+++ b/static/src/js/quote_tabs_badges.js
@@ -1,6 +1,5 @@
 /** @odoo-module **/
 import { registry } from "@web/core/registry";
-import { onMounted, onPatched } from "@odoo/owl";
 
 const PAGES = [
   "page_mano_obra",
@@ -62,11 +61,12 @@ function applyTabStatuses() {
 const service = {
   name: "ccn_quote_tab_colors",
   start() {
-    onMounted(() => applyTabStatuses());
-    onPatched(() => applyTabStatuses());
+    const observer = new MutationObserver(() => applyTabStatuses());
+    observer.observe(document.body, { childList: true, subtree: true });
     document.body.addEventListener("change", (ev) => {
       if (ev.target.closest(".o_form_view.ccn-quote")) applyTabStatuses();
     });
+    applyTabStatuses();
   },
 };
 registry.category("services").add("ccn_quote_tab_colors", service);


### PR DESCRIPTION
## Summary
- avoid using Owl lifecycle hooks outside components
- observe DOM changes to update tab badges

## Testing
- `node --check static/src/js/quote_tabs_badges.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf6815a010832199ec226c90609b86