### PR TITLE
Fix tab status classes and left chevron styling

### DIFF
--- a/static/src/js/quote_tabs_badges.js
+++ b/static/src/js/quote_tabs_badges.js
@@ -46,14 +46,16 @@ function applyTabStatuses() {
       if (!panel) return;
       const link = linkForPanel(form, panel);
       if (!link) return;
+      const tab = link.closest("li");
+      if (!tab) return;
 
       const count = countRows(panel);
       const ack = readAckForPage(panel, pageName);
 
-      link.classList.remove("ccn-status-empty","ccn-status-ack","ccn-status-filled");
-      if (count > 0)       link.classList.add("ccn-status-filled");
-      else if (ack)        link.classList.add("ccn-status-ack");
-      else                 link.classList.add("ccn-status-empty");
+      tab.classList.remove("ccn-tab-empty", "ccn-tab-skip", "ccn-tab-complete");
+      if (count > 0)      tab.classList.add("ccn-tab-complete");
+      else if (ack)       tab.classList.add("ccn-tab-skip");
+      else                tab.classList.add("ccn-tab-empty");
     });
   });
 }

--- a/static/src/scss/quote_tabs.scss
+++ b/static/src/scss/quote_tabs.scss
@@ -1,5 +1,5 @@
 /* SOLO en Service Quote (form con clase ccn-quote) */
-.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link {
+.o_form_view.ccn-quote .o_notebook .nav-tabs li .nav-link {
   position: relative;
   margin-right: 10px;
   padding-right: 2.25rem;
@@ -9,31 +9,31 @@
   clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 50%, calc(100% - 16px) 100%, 0 100%);
 }
 
-.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link:not(:first-child) {
+.o_form_view.ccn-quote .o_notebook .nav-tabs li:not(:first-child) .nav-link {
   margin-left: -16px;
   padding-left: 2.25rem;
   clip-path: polygon(16px 0, calc(100% - 16px) 0, 100% 50%, calc(100% - 16px) 100%, 16px 100%, 0 50%);
 }
 
-.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link.ccn-status-empty {
+.o_form_view.ccn-quote .o_notebook .nav-tabs li.ccn-tab-empty .nav-link {
   background: #e74c3c !important;
   color: #fff !important;
   border-color: #c0392b !important;
 }
 
-.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link.ccn-status-ack {
+.o_form_view.ccn-quote .o_notebook .nav-tabs li.ccn-tab-skip .nav-link {
   background: #f1c40f !important;
   color: #4a3d00 !important;
   border-color: #d4ac0d !important;
 }
 
-.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link.ccn-status-filled {
+.o_form_view.ccn-quote .o_notebook .nav-tabs li.ccn-tab-complete .nav-link {
   background: #2ecc71 !important;
   color: #fff !important;
   border-color: #27ae60 !important;
 }
 
-.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link:hover {
+.o_form_view.ccn-quote .o_notebook .nav-tabs li .nav-link:hover {
   filter: brightness(0.97);
 }
 


### PR DESCRIPTION
## Summary
- Ensure tab badge service applies `ccn-tab-*` classes on `<li>` elements
- Correct SCSS selectors and class names so tabs display colors and left chevron

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68bf6c8ba3848321af0886c8fa5ede38