### PR TITLE
Fix tab color detection by avoiding :scope selector

### DIFF
--- a/static/src/js/quote_notebook.js
+++ b/static/src/js/quote_notebook.js
@@ -12,7 +12,7 @@ function initQuoteTabs(controller) {
     if (!notebook) {
         return;
     }
-    const tabs = notebook.querySelectorAll(":scope > ul.nav-tabs > li");
+    const tabs = notebook.querySelectorAll("ul.nav-tabs > li");
     tabs.forEach((li, index) => {
         li.classList.add("ccn-tab-angle");
         const a = li.querySelector("a");

--- a/static/src/js/quote_tabs_badges.js
+++ b/static/src/js/quote_tabs_badges.js
@@ -23,7 +23,7 @@ function applyTabStatuses() {
     if (!notebook) {
       return;
     }
-    notebook.querySelectorAll(":scope > ul.nav-tabs > li").forEach((tab) => {
+    notebook.querySelectorAll("ul.nav-tabs > li").forEach((tab) => {
       const link = tab.querySelector(".nav-link");
       if (!link) {
         return;


### PR DESCRIPTION
## Summary
- Remove unsupported `:scope` selectors when querying notebook tabs so the color classes can be applied

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf73d233cc8321a68e801dbad5ef66