### PR TITLE
Fix service quote load by guarding lifecycle patches

### DIFF
--- a/static/src/js/quote_notebook.js
+++ b/static/src/js/quote_notebook.js
@@ -68,11 +68,15 @@ function initQuoteTabs(controller) {
 patch(FormController.prototype, {
     patchName: "ccn_quote_notebook",
     async onMounted() {
-        await this._super(...arguments);
+        if (this._super) {
+            await this._super(...arguments);
+        }
         initQuoteTabs(this);
     },
     async onWillUpdateProps() {
-        await this._super(...arguments);
+        if (this._super) {
+            await this._super(...arguments);
+        }
         initQuoteTabs(this);
     },
 });


### PR DESCRIPTION
## Summary
- Avoid calling missing lifecycle methods in the service quote notebook patch

## Testing
- `node --check static/src/js/quote_notebook.js`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bf75a650a08321a7b3e0b6d6c0b659