### PR TITLE
Guard quote tab initialization against missing anchors

### DIFF
--- a/static/src/js/quote_notebook.js
+++ b/static/src/js/quote_notebook.js
@@ -16,6 +16,9 @@ function initQuoteTabs(controller) {
     tabs.forEach((li, index) => {
         li.classList.add("ccn-tab-angle");
         const a = li.querySelector("a");
+        if (!a) {
+            return;
+        }
         const pane = notebook.querySelector(a.getAttribute("href"));
         if (!pane || pane.querySelector(".ccn-skip")) {
             return;


### PR DESCRIPTION
## Summary
- avoid calling `getAttribute` on null anchors in quote notebook tabs

## Testing
- `python -m odoo --stop-after-init --dev=all -d test_db` *(fails: No module named odoo)*

------
https://chatgpt.com/codex/tasks/task_e_68bf78850134832184b07aa5514c7402