### PR TITLE
fix: skip invalid tab selector

### DIFF
--- a/static/src/js/quote_tabs_badges.js
+++ b/static/src/js/quote_tabs_badges.js
@@ -29,10 +29,15 @@ function applyTabStatuses() {
         return;
       }
       const target = link.getAttribute("data-bs-target") || link.getAttribute("href");
-      if (!target) {
+      if (!target || target === "#") {
         return;
       }
-      const panel = notebook.querySelector(target);
+      let panel;
+      try {
+        panel = notebook.querySelector(target);
+      } catch (err) {
+        return;
+      }
       if (!panel) {
         return;
       }


### PR DESCRIPTION
## Summary
- avoid invalid querySelector for tab targets

## Testing
- `node --check static/src/js/quote_tabs_badges.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf7a2490b0832189f6caaaf2370652