### PR TITLE
Fix MutationObserver setup to wait for DOM

### DIFF
--- a/static/src/js/quote_tabs_badges.js
+++ b/static/src/js/quote_tabs_badges.js
@@ -85,15 +85,17 @@ function scheduleApply() {
 function installObserver() {
   if (window.__ccnTabsObserver) return; // evita doble instalación
   const root = document.body;
+  if (!root) return; // DOM aún no listo
+
   const obs = new MutationObserver(scheduleApply);
   obs.observe(root, { childList: true, subtree: true });
   window.__ccnTabsObserver = obs;
 
   // Reaplicar al click en tabs o cambios de campos dentro del form scopeado
-  document.body.addEventListener("click", (ev) => {
+  root.addEventListener("click", (ev) => {
     if (ev.target.closest(".o_form_view.ccn-quote .nav-link")) scheduleApply();
   });
-  document.body.addEventListener("change", (ev) => {
+  root.addEventListener("change", (ev) => {
     if (ev.target.closest(".o_form_view.ccn-quote")) scheduleApply();
   });
 
@@ -108,6 +110,10 @@ window.__ccnTabsDebug = {
 };
 
 // Arranque inmediato cuando el script carga
-(async function bootstrap() {
-  installObserver();
+(function bootstrap() {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", installObserver, { once: true });
+  } else {
+    installObserver();
+  }
 })();


### PR DESCRIPTION
## Summary
- guard against missing `document.body` when installing tab badge observers
- ensure observers install after DOM is ready

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf7f293c7483219db49688c2b191b1