### PR TITLE
Include notebook tab assets

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "CCN Service Quote",
     "summary": "Wizard para cotizar servicios CCN",
-    "version": "18.0.9.2.5",
+    "version": "18.0.9.2.6",
     "author": "Witann Technologies",
     "license": "LGPL-3",
     "category": "Sales/Sales",
@@ -29,9 +29,10 @@
     ],
     "assets": {
         "web.assets_backend": [
-            "ccn_service_quote/static/src/js/ping.js",
             "ccn_service_quote/static/src/js/quote_tabs_badges.js",
+            "ccn_service_quote/static/src/js/quote_notebook.js",
             "ccn_service_quote/static/src/scss/quote_tabs.scss",
+            "ccn_service_quote/static/src/scss/quote_notebook.scss",
         ]
     },
     "installable": True,

--- a/views/assets_force.xml
+++ b/views/assets_force.xml
@@ -6,12 +6,12 @@
               inherit_id="web.assets_backend"
               name="CCN SQ forced assets">
       <xpath expr="." position="inside">
-        <!-- JS mínimo para verificar carga -->
-        <script type="module" src="/ccn_service_quote/static/src/js/ping.js"/>
-        <!-- Tu script de tabs -->
+        <!-- Scripts de tabs -->
         <script type="module" src="/ccn_service_quote/static/src/js/quote_tabs_badges.js"/>
-        <!-- SCSS (declarar como SCSS para que compile) -->
+        <script type="module" src="/ccn_service_quote/static/src/js/quote_notebook.js"/>
+        <!-- Estilos de tabs -->
         <link rel="stylesheet" type="text/scss" href="/ccn_service_quote/static/src/scss/quote_tabs.scss"/>
+        <link rel="stylesheet" type="text/scss" href="/ccn_service_quote/static/src/scss/quote_notebook.scss"/>
       </xpath>
     </template>
   </data>


### PR DESCRIPTION
## Summary
- Load notebook JS and CSS through assets template
- Include dynamic tab color assets in manifest

## Testing
- `python -m py_compile __manifest__.py`
- `node --check static/src/js/quote_tabs_badges.js`
- `node --check static/src/js/quote_notebook.js`


------
https://chatgpt.com/codex/tasks/task_e_68bffb5d8ac4832180292e3290e54818