### PR TITLE
chore: export js modules for bundler

### DIFF
--- a/static/src/js/quote_notebook.js
+++ b/static/src/js/quote_notebook.js
@@ -4,7 +4,7 @@ import { patch } from "@web/core/utils/patch";
 import { FormController } from "@web/views/form/form_controller";
 import { _t } from "@web/core/l10n/translation";
 
-function initQuoteTabs(controller) {
+export function initQuoteTabs(controller) {
     if (!controller.model || controller.model.name !== "ccn.service.quote") {
         return;
     }

--- a/static/src/js/quote_tabs_badges.js
+++ b/static/src/js/quote_tabs_badges.js
@@ -70,8 +70,7 @@ let t;
 function scheduleApply() { clearTimeout(t); t = setTimeout(applyAll, 60); }
 
 // Servicio webclient — asegura ejecución al iniciar el cliente
-const service = {
-  name: "ccn_quote_tabs_service",
+export const ccnQuoteTabsService = {
   start() {
     const root = document.body;
     if (!root) return;
@@ -87,4 +86,4 @@ const service = {
     window.__ccnTabsDebug = { applyAll, installed: () => true };
   },
 };
-registry.category("services").add("ccn_quote_tabs_service", service);
+registry.category("services").add("ccn_quote_tabs_service", ccnQuoteTabsService);


### PR DESCRIPTION
## Summary
- export quote notebook init function
- export tab status service and register it

## Testing
- `node --check static/src/js/quote_tabs_badges.js`
- `node --check static/src/js/quote_notebook.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfff5177e48321b217275c27b274cf