### PR TITLE
Add ccn-quote class to form view container

### DIFF
--- a/views/ccn_quote_form_scope.xml
+++ b/views/ccn_quote_form_scope.xml
@@ -5,7 +5,7 @@
       <field name="model">ccn.service.quote</field>
       <field name="inherit_id" ref="ccn_service_quote.ccn_quote_form_1351"/>
       <field name="arch" type="xml">
-        <xpath expr="//form" position="attributes">
+        <xpath expr="//div[contains(@class,'o_form_view')]" position="attributes">
           <attribute name="class" add="ccn-quote" separator=" "/>
         </xpath>
       </field>


### PR DESCRIPTION
## Summary
- ensure quote form view container div gets `ccn-quote` class instead of the inner `<form>`

## Testing
- `pytest`
- `python - <<'PY' ...` (verify `div.o_form_view` has `ccn-quote`)


------
https://chatgpt.com/codex/tasks/task_e_68c00641ebc08321adbd906fe57f6e5a