### PR TITLE
Fix class injection xpath in service quote form

### DIFF
--- a/views/ccn_quote_form_scope.xml
+++ b/views/ccn_quote_form_scope.xml
@@ -5,7 +5,7 @@
       <field name="model">ccn.service.quote</field>
       <field name="inherit_id" ref="ccn_service_quote.ccn_quote_form_1351"/>
       <field name="arch" type="xml">
-        <xpath expr="//div[contains(@class,'o_form_view')]" position="attributes">
+        <xpath expr="//form" position="attributes">
           <attribute name="class" add="ccn-quote" separator=" "/>
         </xpath>
       </field>


### PR DESCRIPTION
## Summary
- Fix xpath to add ccn-quote class by targeting form tag

## Testing
- `xmllint --noout views/ccn_quote_form_scope.xml`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c007e438608321901b82b0ba507cc9