### PR TITLE
Align quote notebook tab status classes with styles

### DIFF
--- a/static/src/js/quote_notebook.js
+++ b/static/src/js/quote_notebook.js
@@ -29,13 +29,13 @@ export function initQuoteTabs(controller) {
         btn.textContent = _t("No Aplica");
         pane.prepend(btn);
         btn.addEventListener("click", () => {
-            li.classList.remove("ccn-tab-empty");
-            li.classList.add("ccn-tab-skip");
+            li.classList.remove("ccn-status-empty");
+            li.classList.add("ccn-status-ack");
         });
         if (!pane.querySelector("table tbody tr")) {
-            li.classList.add("ccn-tab-empty");
+            li.classList.add("ccn-status-empty");
         } else {
-            li.classList.add("ccn-tab-complete");
+            li.classList.add("ccn-status-filled");
         }
         li.addEventListener(
             "click",
@@ -43,8 +43,8 @@ export function initQuoteTabs(controller) {
                 const prev = Array.from(tabs).slice(0, index);
                 const ok = prev.every(
                     (p) =>
-                        p.classList.contains("ccn-tab-complete") ||
-                        p.classList.contains("ccn-tab-skip")
+                        p.classList.contains("ccn-status-filled") ||
+                        p.classList.contains("ccn-status-ack")
                 );
                 if (!ok) {
                     ev.preventDefault();
@@ -60,8 +60,8 @@ export function initQuoteTabs(controller) {
         );
         const observer = new MutationObserver(() => {
             if (pane.querySelector("table tbody tr")) {
-                li.classList.remove("ccn-tab-empty");
-                li.classList.add("ccn-tab-complete");
+                li.classList.remove("ccn-status-empty", "ccn-status-ack");
+                li.classList.add("ccn-status-filled");
             }
         });
         observer.observe(pane, { childList: true, subtree: true });

--- a/static/src/scss/quote_notebook.scss
+++ b/static/src/scss/quote_notebook.scss
@@ -36,15 +36,6 @@
     border-left-color: #f1c40f;
 }
 
-.ccn-tab-empty > a {
-    background-color: hsl(0, 92%, 60%) !important;
-}
-
-.ccn-tab-empty.ccn-tab-angle::after {
-    border-left-color: #c68484;
-
-}
-
 .ccn-tab-angle.ccn-status-filled::after {
     border-left-color: #2ecc71;
 }


### PR DESCRIPTION
## Summary
- Update quote notebook script to use ccn-status-* classes for tab state
- Simplify notebook styles to match new status classes and arrow colours

## Testing
- `node --check static/src/js/quote_notebook.js`
- `node --check static/src/js/quote_tabs_badges.js`
- `sass static/src/scss/quote_notebook.scss /tmp/quote_notebook.css`
- `sass static/src/scss/quote_tabs.scss /tmp/quote_tabs.css`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c0093b63548321b608387c666dba6d