### PR TITLE
Propagate status classes to quote notebook links

### DIFF
--- a/static/src/js/quote_notebook.js
+++ b/static/src/js/quote_notebook.js
@@ -19,6 +19,7 @@ export function initQuoteTabs(controller) {
         if (!a) {
             return;
         }
+        const targets = [li, a];
         const pane = notebook.querySelector(a.getAttribute("href"));
         if (!pane || pane.querySelector(".ccn-skip")) {
             return;
@@ -29,13 +30,15 @@ export function initQuoteTabs(controller) {
         btn.textContent = _t("No Aplica");
         pane.prepend(btn);
         btn.addEventListener("click", () => {
-            li.classList.remove("ccn-status-empty");
-            li.classList.add("ccn-status-ack");
+            targets.forEach((el) => {
+                el.classList.remove("ccn-status-empty");
+                el.classList.add("ccn-status-ack");
+            });
         });
         if (!pane.querySelector("table tbody tr")) {
-            li.classList.add("ccn-status-empty");
+            targets.forEach((el) => el.classList.add("ccn-status-empty"));
         } else {
-            li.classList.add("ccn-status-filled");
+            targets.forEach((el) => el.classList.add("ccn-status-filled"));
         }
         li.addEventListener(
             "click",
@@ -60,8 +63,10 @@ export function initQuoteTabs(controller) {
         );
         const observer = new MutationObserver(() => {
             if (pane.querySelector("table tbody tr")) {
-                li.classList.remove("ccn-status-empty", "ccn-status-ack");
-                li.classList.add("ccn-status-filled");
+                targets.forEach((el) => {
+                    el.classList.remove("ccn-status-empty", "ccn-status-ack");
+                    el.classList.add("ccn-status-filled");
+                });
             }
         });
         observer.observe(pane, { childList: true, subtree: true });


### PR DESCRIPTION
## Summary
- apply `ccn-status-*` classes to both tab list elements and their links in quote notebook

## Testing
- `python -m pytest`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c00b5565d8832184127a63f2e4dbb7