### PR TITLE
Ensure Service Quote tabs get colored

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "CCN Service Quote",
     "summary": "Wizard para cotizar servicios CCN",
-    "version": "18.0.9.2.11",
+    "version": "18.0.9.2.12",
     "author": "Witann Technologies",
     "license": "LGPL-3",
     "category": "Sales/Sales",

--- a/static/src/js/quote_tabs_badges.js
+++ b/static/src/js/quote_tabs_badges.js
@@ -12,9 +12,18 @@ import { registry } from "@web/core/registry";
 function ensureScopeClass() {
   // Marca como .ccn-quote cualquier form que tenga señales de Service Quote
   document.querySelectorAll(".o_form_view:not(.ccn-quote)").forEach((form) => {
-    const hasQuotePages = form.querySelector('.o_notebook .o_notebook_page[name^="page_"]');
-    const hasCurrentSite = form.querySelector('.o_field_widget[name="current_site_id"], [name="current_site_id"]');
-    if (hasQuotePages || hasCurrentSite) form.classList.add("ccn-quote");
+    const resModel =
+      form.getAttribute("data-res-model") ||
+      (form.dataset ? form.dataset.resModel || form.dataset.model : null);
+    const hasQuotePages = form.querySelector(
+      '.o_notebook .o_notebook_page[name^="page_"]'
+    );
+    const hasCurrentSite = form.querySelector(
+      '.o_field_widget[name="current_site_id"], [name="current_site_id"]'
+    );
+    if (resModel === "ccn.service.quote" || hasQuotePages || hasCurrentSite) {
+      form.classList.add("ccn-quote");
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- detect Service Quote forms via `data-res-model` to apply tab colors
- bump version

## Testing
- `node --check static/src/js/quote_tabs_badges.js`
- `python -m py_compile __manifest__.py`


------
https://chatgpt.com/codex/tasks/task_e_68c00dec9abc8321841e6bbea9e88228