### PR TITLE
Add generic status color classes

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "CCN Service Quote",
     "summary": "Wizard para cotizar servicios CCN",
-    "version": "18.0.9.2.13",
+    "version": "18.0.9.2.14",
     "author": "Witann Technologies",
     "license": "LGPL-3",
     "category": "Sales/Sales",
@@ -32,6 +32,7 @@
             "ccn_service_quote/static/src/js/quote_notebook.js",
             "ccn_service_quote/static/src/scss/quote_tabs.scss",
             "ccn_service_quote/static/src/scss/quote_notebook.scss",
+            "ccn_service_quote/static/src/scss/quote_status.scss",
         ]
     },
     "installable": True,

--- a/static/src/scss/quote_status.scss
+++ b/static/src/scss/quote_status.scss
@@ -1,0 +1,15 @@
+/* Generic status background classes for CCN */
+.ccn-status-empty {
+  background-color: #e74c3c !important;
+  color: #fff !important;
+}
+
+.ccn-status-ack {
+  background-color: #f1c40f !important;
+  color: #4a3d00 !important;
+}
+
+.ccn-status-filled {
+  background-color: #2ecc71 !important;
+  color: #fff !important;
+}


### PR DESCRIPTION
## Summary
- expose background color classes for status states
- register status styles in assets

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c01398af608321bd5ec15b4807c991