### PR TITLE
Fix quote tabs showing lines for other rubros

### DIFF
--- a/static/src/js/quote_tabs_badges.js
+++ b/static/src/js/quote_tabs_badges.js
@@ -27,10 +27,37 @@ function ensureScopeClass() {
   });
 }
 
+function panelCode(panelEl) {
+  const name = panelEl.getAttribute("name") || "";
+  const m = name.match(/^page_(.+)$/);
+  return m ? m[1] : null;
+}
+
+function filterRows(panelEl) {
+  const code = panelCode(panelEl);
+  if (!code) return;
+  panelEl
+    .querySelectorAll(".o_list_view tbody tr.o_data_row")
+    .forEach((row) => {
+      const cell = row.querySelector('td[data-name="rubro_code"]');
+      const rowCode = cell ? cell.textContent.trim() : "";
+      row.style.display = rowCode === code ? "" : "none";
+    });
+}
+
 function countRows(panelEl) {
-  let rows = panelEl.querySelectorAll(".o_list_view tbody tr.o_data_row");
+  filterRows(panelEl);
+  let rows = Array.from(
+    panelEl.querySelectorAll(
+      ".o_list_view tbody tr.o_data_row"
+    )
+  ).filter((r) => r.style.display !== "none");
   if (rows.length) return rows.length;
-  rows = panelEl.querySelectorAll(".o_list_view tbody tr:not(.o_list_record_add)");
+  rows = Array.from(
+    panelEl.querySelectorAll(
+      ".o_list_view tbody tr:not(.o_list_record_add)"
+    )
+  ).filter((r) => r.style.display !== "none");
   return rows.length || 0;
 }
 

--- a/views/quote_line_list_inline.xml
+++ b/views/quote_line_list_inline.xml
@@ -8,6 +8,7 @@
       <field name="arch" type="xml">
         <list editable="bottom" string="Líneas del rubro">
           <field name="rubro_id" invisible="1" column_invisible="1"/>
+          <field name="rubro_code" invisible="1" column_invisible="1"/>
 
           <!-- Producto/Servicio del rubro (filtro por rubro del template) -->
           <field name="product_id" required="1"


### PR DESCRIPTION
## Summary
- hide quote lines that belong to other rubros when switching tabs
- expose rubro code in inline quote line view for client-side filtering

## Testing
- `node --check static/src/js/quote_tabs_badges.js`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c0184104608321b081b7a474291c82