### PR TITLE
Fix tab status and filtering for CCN service quotes

### DIFF
--- a/static/src/js/quote_notebook.js
+++ b/static/src/js/quote_notebook.js
@@ -5,7 +5,7 @@ import { FormController } from "@web/views/form/form_controller";
 import { _t } from "@web/core/l10n/translation";
 
 function panelCode(pane) {
-    const name = pane.getAttribute("name") || "";
+    const name = pane.getAttribute("name") || pane.dataset.name || "";
     const m = name.match(/^page_(.+)$/);
     return m ? m[1] : null;
 }

--- a/static/src/js/quote_tabs_badges.js
+++ b/static/src/js/quote_tabs_badges.js
@@ -28,7 +28,7 @@ function ensureScopeClass() {
 }
 
 function panelCode(panelEl) {
-  const name = panelEl.getAttribute("name") || "";
+  const name = panelEl.getAttribute("name") || panelEl.dataset.name || "";
   const m = name.match(/^page_(.+)$/);
   return m ? m[1] : null;
 }
@@ -42,7 +42,7 @@ function filterRows(panelEl) {
       const cell = row.querySelector('td[data-name="rubro_code"]');
       const rowCode = cell
         ? (cell.dataset.value || cell.textContent.trim())
-        : "";
+        : row.dataset.rubroCode || "";
       row.style.display = rowCode === code ? "" : "none";
     });
 }
@@ -54,7 +54,9 @@ function countRows(panelEl) {
     panelEl.querySelectorAll(".o_list_view tbody tr.o_data_row")
   ).filter((row) => {
     const cell = row.querySelector('td[data-name="rubro_code"]');
-    const rowCode = cell ? (cell.dataset.value || cell.textContent.trim()) : "";
+    const rowCode = cell
+      ? (cell.dataset.value || cell.textContent.trim())
+      : row.dataset.rubroCode || "";
     return rowCode === code;
   }).length;
 }


### PR DESCRIPTION
## Summary
- Ensure quote tab detection uses `data-name` attribute
- Filter tab rows by `rubro_code` and track unfilled/acknowledged states

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/src/js/quote_notebook.js`
- `node --check static/src/js/quote_tabs_badges.js`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c025c0e6d08321ae8c2071b170a1d4