### PR TITLE
Fix rubro tab filtering and status colors

### DIFF
--- a/static/src/js/quote_tabs_badges.js
+++ b/static/src/js/quote_tabs_badges.js
@@ -33,16 +33,24 @@ function panelCode(panelEl) {
   return m ? m[1] : null;
 }
 
+function rowRubroCode(row) {
+  const cell = row.querySelector('td[data-name="rubro_code"]');
+  const code = cell
+    ? (cell.dataset.value || cell.textContent.trim())
+    : row.dataset.rubroCode || "";
+  if (code) {
+    row.dataset.rubroCode = code;
+  }
+  return code;
+}
+
 function filterRows(panelEl) {
   const code = panelCode(panelEl);
   if (!code) return;
   panelEl
     .querySelectorAll(".o_list_view tbody tr.o_data_row")
     .forEach((row) => {
-      const cell = row.querySelector('td[data-name="rubro_code"]');
-      const rowCode = cell
-        ? (cell.dataset.value || cell.textContent.trim())
-        : row.dataset.rubroCode || "";
+      const rowCode = rowRubroCode(row);
       row.style.display = rowCode === code ? "" : "none";
     });
 }
@@ -53,10 +61,7 @@ function countRows(panelEl) {
   return Array.from(
     panelEl.querySelectorAll(".o_list_view tbody tr.o_data_row")
   ).filter((row) => {
-    const cell = row.querySelector('td[data-name="rubro_code"]');
-    const rowCode = cell
-      ? (cell.dataset.value || cell.textContent.trim())
-      : row.dataset.rubroCode || "";
+    const rowCode = rowRubroCode(row);
     return rowCode === code;
   }).length;
 }

--- a/views/quote_line_list_inline.xml
+++ b/views/quote_line_list_inline.xml
@@ -8,7 +8,7 @@
       <field name="arch" type="xml">
         <list editable="bottom" string="Líneas del rubro">
           <field name="rubro_id" invisible="1" column_invisible="1"/>
-          <field name="rubro_code" invisible="1" column_invisible="1"/>
+          <field name="rubro_code" invisible="1"/>
 
           <!-- Producto/Servicio del rubro (filtro por rubro del template) -->
           <field name="product_id" required="1"

--- a/views/quote_line_tree_inline.xml
+++ b/views/quote_line_tree_inline.xml
@@ -35,7 +35,7 @@
           <field name="quote_id" invisible="1" column_invisible="1"/>
           <field name="site_id" invisible="1" column_invisible="1"/>
           <field name="type" invisible="1" column_invisible="1"/>
-          <field name="rubro_code" invisible="1" column_invisible="1"/>
+          <field name="rubro_code" invisible="1"/>
         </list>
       </field>
     </record>


### PR DESCRIPTION
## Summary
- Keep each rubro's products confined to its own tab in the quote form
- Cache rubro codes on rows to ensure tab badges update correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/src/js/quote_tabs_badges.js`
- `xmllint --noout views/quote_line_list_inline.xml views/quote_line_tree_inline.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c028f29fd48321acd20da8b0fb7c2b