### PR TITLE
Hide 'Código Fijo' column and improve tab logic

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "CCN Service Quote",
     "summary": "Wizard para cotizar servicios CCN",
-    "version": "18.0.9.2.25",
+    "version": "18.0.9.2.26",
     "author": "Witann Technologies",
     "license": "LGPL-3",
     "category": "Sales/Sales",

--- a/static/src/js/quote_tabs_badges.js
+++ b/static/src/js/quote_tabs_badges.js
@@ -129,8 +129,12 @@ export const ccnQuoteTabsService = {
     // Observer de todo el webclient
     const obs = new MutationObserver(scheduleApply);
     obs.observe(root, { childList: true, subtree: true });
-    // Reaplicar al navegar entre tabs o cambiar campos
-    root.addEventListener("click",  (ev) => { if (ev.target.closest(".o_form_view .nav-link")) scheduleApply(); });
+    // Reaplicar al navegar entre tabs, marcar "No Aplica" o cambiar campos
+    root.addEventListener("click",  (ev) => {
+      if (ev.target.closest(".o_form_view .nav-link") || ev.target.closest(".o_form_view .ccn-skip")) {
+        scheduleApply();
+      }
+    });
     root.addEventListener("change", (ev) => { if (ev.target.closest(".o_form_view")) scheduleApply(); });
     root.addEventListener("shown.bs.tab", (ev) => {
       if (ev.target.closest(".o_form_view .nav-link")) scheduleApply();

--- a/views/quote_line_list_inline.xml
+++ b/views/quote_line_list_inline.xml
@@ -8,7 +8,7 @@
       <field name="arch" type="xml">
         <list editable="bottom" string="Líneas del rubro">
           <field name="rubro_id" invisible="1" column_invisible="1"/>
-          <field name="rubro_code" invisible="1"/>
+          <field name="rubro_code" invisible="1" column_invisible="1"/>
 
           <!-- Producto/Servicio del rubro (filtro por rubro del template) -->
           <field name="product_id" required="1"

--- a/views/quote_line_tree_inline.xml
+++ b/views/quote_line_tree_inline.xml
@@ -35,7 +35,7 @@
           <field name="quote_id" invisible="1" column_invisible="1"/>
           <field name="site_id" invisible="1" column_invisible="1"/>
           <field name="type" invisible="1" column_invisible="1"/>
-          <field name="rubro_code" invisible="1"/>
+          <field name="rubro_code" invisible="1" column_invisible="1"/>
         </list>
       </field>
     </record>


### PR DESCRIPTION
## Summary
- hide rubro_code field to drop the stray **Código Fijo** column from quote line lists
- ensure tab badges react to the *No Aplica* button by reapplying color logic
- bump module version to 18.0.9.2.26

## Testing
- ✅ `pytest`
- ✅ `python -m py_compile __manifest__.py`


------
https://chatgpt.com/codex/tasks/task_e_68c02ad6300c83218c6a67e8a052cd18