### PR TITLE
Fix tab colors based on backend state

### DIFF
--- a/static/src/js/quote_notebook.js
+++ b/static/src/js/quote_notebook.js
@@ -49,6 +49,10 @@ export function initQuoteTabs(controller) {
             );
             pane.dataset.ccnAck = ack ? "0" : "1";
             btn.textContent = pane.dataset.ccnAck === "1" ? _t("Quitar No Aplica") : _t("No Aplica");
+            const stateInput = controller.el.querySelector(`[name="rubro_state_${code}"]`);
+            if (stateInput) {
+                stateInput.value = pane.dataset.ccnAck === "1" ? "yellow" : "red";
+            }
             if (window.__ccnTabsDebug && window.__ccnTabsDebug.applyAll) {
                 window.__ccnTabsDebug.applyAll();
             }


### PR DESCRIPTION
## Summary
- derive tab color status from backend `rubro_state_*` fields
- keep `rubro_state_*` fields in sync when toggling "No Aplica" buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c03421f43c83218827aa1ed2cfe229