### PR TITLE
fix: detect active tab for color logic

### DIFF
--- a/static/src/js/quote_tabs_badges.js
+++ b/static/src/js/quote_tabs_badges.js
@@ -80,8 +80,12 @@ function linkForPanel(form, panelEl) {
 }
 
 function applyInForm(form) {
-  const panels = Array.from(form.querySelectorAll(".o_notebook .o_notebook_page"));
-  const activePanel = panels.find((p) => p.querySelector(".o_list_view"));
+  const panels = Array.from(
+    form.querySelectorAll(".o_notebook .o_notebook_page")
+  );
+  const activePanel =
+    panels.find((p) => p.classList.contains("active") || p.classList.contains("show")) ||
+    panels.find((p) => p.querySelector(".o_list_view"));
 
   if (activePanel) {
     // Contar líneas por rubro y mostrar solo las del panel activo


### PR DESCRIPTION
## Summary
- ensure tab state logic finds currently active notebook page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c035a354188321ae5ae3345f61ef59