### PR TITLE
fix: ensure tab colors load via form class

### DIFF
--- a/static/src/js/quote_tabs_badges.js
+++ b/static/src/js/quote_tabs_badges.js
@@ -4,14 +4,14 @@ import { registry } from "@web/core/registry";
 
 /*
   Tabs de colores SOLO en Service Quote.
-  - Auto-scope: si el <form> no tiene .ccn-quote, se la añade al vuelo.
+  - Auto-scope: si el formulario <form> no tiene .ccn-quote, se la añade al vuelo.
   - Detección automática de páginas (no requiere lista fija).
   - Pone clases de estado en <li> y en <a.nav-link>.
 */
 
 function ensureScopeClass() {
-  // Marca como .ccn-quote cualquier form que tenga señales de Service Quote
-  document.querySelectorAll(".o_form_view:not(.ccn-quote)").forEach((form) => {
+  // Marca como .ccn-quote cualquier formulario que tenga señales de Service Quote
+  document.querySelectorAll(".o_form_view form:not(.ccn-quote)").forEach((form) => {
     const resModel =
       form.getAttribute("data-res-model") ||
       (form.dataset ? form.dataset.resModel || form.dataset.model : null);
@@ -128,7 +128,7 @@ function applyInForm(form) {
 
 function applyAll() {
   ensureScopeClass();
-  document.querySelectorAll(".o_form_view.ccn-quote").forEach(applyInForm);
+  document.querySelectorAll("form.ccn-quote").forEach(applyInForm);
 }
 
 // Debounce

--- a/static/src/scss/quote_tabs.scss
+++ b/static/src/scss/quote_tabs.scss
@@ -1,11 +1,11 @@
 /* SOLO en Service Quote (form con clase ccn-quote) */
-.o_form_view.ccn-quote .o_notebook .nav-tabs {
+form.ccn-quote .o_notebook .nav-tabs {
   /* por si el chevrón se corta en algunos temas */
   overflow: visible;
 }
 
-.o_form_view.ccn-quote .o_notebook .nav-tabs li .nav-link,
-.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link {
+form.ccn-quote .o_notebook .nav-tabs li .nav-link,
+form.ccn-quote .o_notebook .nav-tabs .nav-link {
   position: relative;
   margin-right: 10px;
   padding-right: 2.25rem;
@@ -16,36 +16,36 @@
 }
 
 /* encadenamiento visual (chevrón continuo) */
-.o_form_view.ccn-quote .o_notebook .nav-tabs li:not(:first-child) .nav-link,
-.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link + .nav-link {
+form.ccn-quote .o_notebook .nav-tabs li:not(:first-child) .nav-link,
+form.ccn-quote .o_notebook .nav-tabs .nav-link + .nav-link {
   margin-left: -16px;
   padding-left: 2.25rem;
   clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 50%, calc(100% - 16px) 100%, 0 100%, 16px 50%);
 }
 
 /* ESTADOS — cubre clase en <li> y/o en <a> */
-.o_form_view.ccn-quote .o_notebook .nav-tabs li.ccn-status-empty .nav-link,
-.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link.ccn-status-empty {
+form.ccn-quote .o_notebook .nav-tabs li.ccn-status-empty .nav-link,
+form.ccn-quote .o_notebook .nav-tabs .nav-link.ccn-status-empty {
   background: #e74c3c !important;
   color: #fff !important;
   border-color: #c0392b !important;
 }
 
-.o_form_view.ccn-quote .o_notebook .nav-tabs li.ccn-status-ack .nav-link,
-.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link.ccn-status-ack {
+form.ccn-quote .o_notebook .nav-tabs li.ccn-status-ack .nav-link,
+form.ccn-quote .o_notebook .nav-tabs .nav-link.ccn-status-ack {
   background: #f1c40f !important;
   color: #4a3d00 !important;
   border-color: #d4ac0d !important;
 }
 
-.o_form_view.ccn-quote .o_notebook .nav-tabs li.ccn-status-filled .nav-link,
-.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link.ccn-status-filled {
+form.ccn-quote .o_notebook .nav-tabs li.ccn-status-filled .nav-link,
+form.ccn-quote .o_notebook .nav-tabs .nav-link.ccn-status-filled {
   background: #2ecc71 !important;
   color: #fff !important;
   border-color: #27ae60 !important;
 }
 
-.o_form_view.ccn-quote .o_notebook .nav-tabs li .nav-link:hover,
-.o_form_view.ccn-quote .o_notebook .nav-tabs .nav-link:hover {
+form.ccn-quote .o_notebook .nav-tabs li .nav-link:hover,
+form.ccn-quote .o_notebook .nav-tabs .nav-link:hover {
   filter: brightness(0.97);
 }


### PR DESCRIPTION
## Summary
- align tab-color service with `ccn-quote` class on `<form>`
- style quote tabs based on form marker for consistent colors

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c038a949f48321bd15d3ec467f1858