### PR TITLE
Fix chevron visibility in Service Quote

### DIFF
--- a/static/src/scss/quote_tabs.scss
+++ b/static/src/scss/quote_tabs.scss
@@ -1,7 +1,7 @@
 /* SOLO en Service Quote (form con clase ccn-quote) */
 form.ccn-quote .o_notebook .nav-tabs {
   /* por si el chevrón se corta en algunos temas */
-  overflow: visible;
+  overflow: visible !important;
 }
 
 form.ccn-quote .o_notebook .nav-tabs li .nav-link,


### PR DESCRIPTION
## Summary
- ensure chevron shapes are not clipped in quote tabs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c03c4b82908321a706fd70c7d41797