### PR TITLE
Ensure chevron visible in Service Quote tabs

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "CCN Service Quote",
     "summary": "Wizard para cotizar servicios CCN",
-    "version": "18.0.9.2.36",
+    "version": "18.0.9.2.37",
     "author": "Witann Technologies",
     "license": "LGPL-3",
     "category": "Sales/Sales",

--- a/static/src/scss/quote_tabs.scss
+++ b/static/src/scss/quote_tabs.scss
@@ -1,4 +1,9 @@
 /* SOLO en Service Quote (form con clase ccn-quote) */
+form.ccn-quote .o_notebook {
+  /* en algunos temas el contenedor oculta el chevrón */
+  overflow: visible !important;
+}
+
 form.ccn-quote .o_notebook .nav-tabs {
   /* por si el chevrón se corta en algunos temas */
   overflow: visible !important;


### PR DESCRIPTION
## Summary
- Prevent notebook container from clipping chevron so tab arrows remain visible
- Bump module version

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c03d43a82883219851087ca1f259eb