### PR TITLE
Use rubro state fields for tab colors

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "Cotizador Especial CCN",
     "summary": "Wizard para cotizar servicios CCN",
-    "version": "18.0.9.3.6",
+    "version": "18.0.9.3.7",
     "author": "Witann Technologies",
     "license": "LGPL-3",
     "category": "Sales/Sales",

--- a/static/src/js/quote_tabs_badges.js
+++ b/static/src/js/quote_tabs_badges.js
@@ -2,12 +2,21 @@
 
 import { registry } from "@web/core/registry";
 
-function log(...a) { (window.__ccnLog = window.__ccnLog || []).push(a); try { console.log("[CCN Tabs]", ...a); } catch(e){} }
+function log(...a) {
+  (window.__ccnLog = window.__ccnLog || []).push(a);
+  try {
+    console.log("[CCN Tabs]", ...a);
+  } catch (e) {}
+}
 
 function ensureScopeClass() {
   document.querySelectorAll(".o_form_view:not(.ccn-quote)").forEach((form) => {
-    const hasQuotePages  = form.querySelector('.o_notebook .o_notebook_page[name^="page_"]');
-    const hasCurrentSite = form.querySelector('.o_field_widget[name="current_site_id"], [name="current_site_id"]');
+    const hasQuotePages = form.querySelector(
+      '.o_notebook .o_notebook_page[name^="page_"]'
+    );
+    const hasCurrentSite = form.querySelector(
+      '.o_field_widget[name="current_site_id"], [name="current_site_id"]'
+    );
     if (hasQuotePages || hasCurrentSite) {
       form.classList.add("ccn-quote");
       log("scope class added to form");
@@ -15,18 +24,17 @@ function ensureScopeClass() {
   });
 }
 
-function countRows(panelEl) {
-  let rows = panelEl.querySelectorAll(".o_list_view tbody tr.o_data_row");
-  if (rows.length) return rows.length;
-  rows = panelEl.querySelectorAll(".o_list_view tbody tr:not(.o_list_record_add)");
-  return rows.length || 0;
+function panelCode(panelEl) {
+  const name = panelEl.getAttribute("name") || panelEl.dataset.name || "";
+  const m = name.match(/^page_(.+)$/);
+  return m ? m[1] : null;
 }
 
-function readAck(panelEl) {
-  const el = panelEl.querySelector(
-    '.o_field_widget input[type="checkbox"][name$="_empty"], input[type="checkbox"][name$="_empty"]'
-  );
-  return el ? !!el.checked : false;
+function readState(form, panelEl) {
+  const code = panelCode(panelEl);
+  if (!code) return "red";
+  const el = form.querySelector(`[name="rubro_state_${code}"]`);
+  return el ? el.value || "red" : "red";
 }
 
 function linkForPanel(form, panelEl) {
@@ -45,13 +53,20 @@ function applyInForm(form) {
     const li = link.closest("li");
     const targets = li ? [link, li] : [link];
 
-    const count = countRows(panel);
-    const ack   = readAck(panel);
+    const state = readState(form, panel);
 
-    targets.forEach((el) => el.classList.remove("ccn-status-empty","ccn-status-ack","ccn-status-filled"));
-    if (count > 0)       targets.forEach((el) => el.classList.add("ccn-status-filled"));
-    else if (ack)        targets.forEach((el) => el.classList.add("ccn-status-ack"));
-    else                 targets.forEach((el) => el.classList.add("ccn-status-empty"));
+    targets.forEach((el) =>
+      el.classList.remove(
+        "ccn-status-empty",
+        "ccn-status-ack",
+        "ccn-status-filled"
+      )
+    );
+    if (state === "ok")
+      targets.forEach((el) => el.classList.add("ccn-status-filled"));
+    else if (state === "yellow")
+      targets.forEach((el) => el.classList.add("ccn-status-ack"));
+    else targets.forEach((el) => el.classList.add("ccn-status-empty"));
   });
 }
 
@@ -59,7 +74,10 @@ function applyAll() {
   try {
     ensureScopeClass();
     const forms = document.querySelectorAll(".o_form_view.ccn-quote");
-    if (!forms.length) { log("no .ccn-quote forms found yet"); return; }
+    if (!forms.length) {
+      log("no .ccn-quote forms found yet");
+      return;
+    }
     forms.forEach(applyInForm);
     log("applyAll OK on", forms.length, "form(s)");
   } catch (e) {
@@ -68,19 +86,29 @@ function applyAll() {
 }
 
 let t;
-function scheduleApply() { clearTimeout(t); t = setTimeout(applyAll, 80); }
+function scheduleApply() {
+  clearTimeout(t);
+  t = setTimeout(applyAll, 80);
+}
 
 const service = {
   name: "ccn_quote_tabs_service",
   start() {
     log("service start");
     const root = document.body;
-    if (!root) { log("no document.body"); return; }
+    if (!root) {
+      log("no document.body");
+      return;
+    }
 
     const obs = new MutationObserver(scheduleApply);
     obs.observe(root, { childList: true, subtree: true });
-    root.addEventListener("click",  (ev) => { if (ev.target.closest(".o_form_view .nav-link")) scheduleApply(); });
-    root.addEventListener("change", (ev) => { if (ev.target.closest(".o_form_view")) scheduleApply(); });
+    root.addEventListener("click", (ev) => {
+      if (ev.target.closest(".o_form_view .nav-link")) scheduleApply();
+    });
+    root.addEventListener("change", (ev) => {
+      if (ev.target.closest(".o_form_view")) scheduleApply();
+    });
 
     // primera pasada (doble por si tarda el render)
     setTimeout(scheduleApply, 0);


### PR DESCRIPTION
## Summary
- Compute tab color classes from `rubro_state_*` fields instead of DOM counts
- Bump module version to 18.0.9.3.7

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0f575054883219c8847dc4922fdf5