### PR TITLE
fix: detect rows without class for tab color

### DIFF
--- a/static/src/js/quote_tabs_badges.js
+++ b/static/src/js/quote_tabs_badges.js
@@ -152,8 +152,12 @@ function countRowsForCode(form, code) {
 }
 
 function countRows(panelEl) {
-  // Cuenta solo filas de datos reales (tr.o_data_row)
-  const rows = panelEl.querySelectorAll(".o_list_view tbody tr.o_data_row");
+  // Cuenta filas de datos reales, incluyendo registros recién agregados
+  let rows = panelEl.querySelectorAll(".o_list_view tbody tr.o_data_row");
+  if (rows.length) return rows.length;
+  rows = panelEl.querySelectorAll(
+    ".o_list_view tbody tr:not(.o_list_record_add)"
+  );
   return rows.length || 0;
 }
 


### PR DESCRIPTION
## Summary
- count records without `o_data_row` class so tabs turn green when filled

## Testing
- `node --check static/src/js/quote_tabs_badges.js`


------
https://chatgpt.com/codex/tasks/task_e_68c32f2beb8083218a276f217ac674fb