### PR TITLE
Fix tab color styles for inactive states

### DIFF
--- a/static/src/scss/quote_tabs_inactive_colors.scss
+++ b/static/src/scss/quote_tabs_inactive_colors.scss
@@ -8,30 +8,33 @@
 .o_notebook .nav-tabs {
   /* OK */
   .nav-link[data-ccn-state="ok"]:not(.active),
-  li[data-ccn-state="ok"]:not(.active) > .nav-link {
+  li[data-ccn-state="ok"] > .nav-link:not(.active) {
     background-color: var(--ccn-ok) !important;
     border-color: var(--ccn-ok) !important;
     color: #fff !important;
+    background-image: none !important;
   }
   /* YELLOW */
   .nav-link[data-ccn-state="yellow"]:not(.active),
-  li[data-ccn-state="yellow"]:not(.active) > .nav-link {
+  li[data-ccn-state="yellow"] > .nav-link:not(.active) {
     background-color: var(--ccn-warn) !important;
     border-color: var(--ccn-warn) !important;
     color: #1f2937 !important;
+    background-image: none !important;
   }
   /* RED */
   .nav-link[data-ccn-state="red"]:not(.active),
-  li[data-ccn-state="red"]:not(.active) > .nav-link {
+  li[data-ccn-state="red"] > .nav-link:not(.active) {
     background-color: var(--ccn-empty) !important;
     border-color: var(--ccn-empty) !important;
     color: #fff !important;
+    background-image: none !important;
   }
 
   /* Chevrons (si tu tema los pinta con ::after; no cambiamos geometría) */
   .nav-link[data-ccn-state]:not(.active)::after,
-  li[data-ccn-state]:not(.active)::after,
-  li[data-ccn-state]:not(.active) > .nav-link::after {
+  li[data-ccn-state] > .nav-link:not(.active)::after,
+  li[data-ccn-state]:not(.active)::after {
     border-left-color: currentColor; /* hereda, usualmente no hace falta más */
   }
 }


### PR DESCRIPTION
## Summary
- Ensure inactive notebook tabs use state-specific colors
- Remove theme background images that overrode custom colors

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c48c915e008321bb5b48ed87b53f21