### PR TITLE
Fix quote form notebook xpath

### DIFF
--- a/views/site_views.xml
+++ b/views/site_views.xml
@@ -92,8 +92,8 @@
         </xpath>
 
         <!-- 2) Sustituye el antiguo bloque de líneas por el notebook completo -->
-        <xpath expr="//form//field[@name='line_ids']" position="replace">
-          <notebook>
+        <xpath expr="//form/notebook[@invisible='not current_service_type']" position="replace">
+          <notebook invisible="not current_service_type">
 
             <!-- A) Sitio actual (indicadores ARRIBA y líneas ABAJO, embebiendo el form del sitio) -->
             <page string="Sitio actual">


### PR DESCRIPTION
## Summary
- update the inherited view to replace the real notebook element instead of a non-existent field
- preserve the notebook's visibility behavior when embedding the site form

## Testing
- not run (environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68d18c24399883218c1c37699104102b