### PR TITLE
Replace base price field references with computed field

### DIFF
--- a/views/quote_line_domain.xml
+++ b/views/quote_line_domain.xml
@@ -23,9 +23,9 @@
 
               <field name="quantity"/>
               <field name="tabulator_percent"/>
-              <field name="base_price_unit"/>
-              <field name="price_unit_final"/>
-              <field name="total_price"/>
+              <field name="product_base_price" readonly="1"/>
+              <field name="price_unit_final" readonly="1"/>
+              <field name="total_price" readonly="1"/>
               <field name="currency_id" invisible="1"/>
             </list>
 
@@ -38,7 +38,7 @@
                                 ('product_tmpl_id.ccn_rubro_ids.code','in',[context.get('ctx_rubro_code'), rubro_code])]"/>
                 <field name="quantity"/>
                 <field name="tabulator_percent"/>
-                <field name="base_price_unit"/>
+                <field name="product_base_price" readonly="1"/>
                 <field name="price_unit_final" readonly="1"/>
                 <field name="total_price" readonly="1"/>
               </group>

--- a/views/site_views.xml
+++ b/views/site_views.xml
@@ -28,8 +28,8 @@
                     <list editable="bottom" string="Líneas del sitio">
                       <field name="product_id" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"/>
                       <field name="quantity"/>
-                    <!-- Reemplaza base_price_unit por el campo real que sí tienes -->
-                    <field name="price_unit_final" string="Precio Unitario"/>
+                    <field name="product_base_price" string="Precio base" readonly="1"/>
+                    <field name="price_unit_final" string="Precio Unitario" readonly="1"/>
                     <field name="tabulator_percent" string="Tabulador"/>
                     <field name="amount_tax" string="IVA" readonly="1"/>
                     <field name="total_price" string="Subtotal" readonly="1"/>
@@ -122,7 +122,7 @@
                               <field name="rubro_id"/>
                               <field name="product_id" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"/>
                               <field name="quantity"/>
-                              <field name="base_price_unit"/>
+                              <field name="product_base_price" readonly="1"/>
                               <field name="tabulator_percent"/>
                               <field name="price_unit_final" readonly="1"/>
                               <field name="total_price" readonly="1"/>
@@ -132,7 +132,7 @@
                                 <field name="rubro_id"/>
                                 <field name="product_id" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"/>
                                 <field name="quantity"/>
-                                <field name="base_price_unit"/>
+                                <field name="product_base_price" readonly="1"/>
                                 <field name="tabulator_percent"/>
                                 <field name="price_unit_final" readonly="1"/>
                                 <field name="total_price" readonly="1"/>


### PR DESCRIPTION
## Summary
- replace base_price_unit references in site-related views with the computed product_base_price field
- ensure product_base_price, price_unit_final, and totals render as readonly in quote line forms and lists

## Testing
- not run (environment only provides source code)

------
https://chatgpt.com/codex/tasks/task_e_68d18dfc3744832192dcc90627b591b6