### PR TITLE
Add legacy alias for pick quote wizard action

### DIFF
--- a/models/sale_order.py
+++ b/models/sale_order.py
@@ -54,6 +54,10 @@ class SaleOrder(models.Model):
 
         return action
 
+    def action_open_pick_quote_wizard(self):
+        """Alias legacy para compatibilidad con vistas anteriores."""
+        return self.action_ccn_add_service_quote()
+
     # ----------------- Helpers de producto "contenedor" -----------------
 
     def _ccn_get_category_product(self, category):


### PR DESCRIPTION
## Summary
- add a compatibility wrapper on `sale.order` so legacy views calling `action_open_pick_quote_wizard` still work

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d19377446883219795fe463405b9ec