### PR TITLE
Ensure CCN quote menu is exposed as application

### DIFF
--- a/views/ccn_menus.xml
+++ b/views/ccn_menus.xml
@@ -2,7 +2,10 @@
 <odoo>
   <data>
     <!-- Menú raíz SIN acción -->
-    <menuitem id="ccn_root_menu" name="Cotizador Especial CCN" sequence="20"/>
+    <menuitem id="ccn_root_menu"
+              name="Cotizador Especial CCN"
+              sequence="20"
+              app="True"/>
     <!-- Acción válida (la que corresponde a 478 si la tienes creada desde XML) -->
     <record id="ccn_action_quotes" model="ir.actions.act_window">
         <field name="name">Cotizaciones de Servicio</field>


### PR DESCRIPTION
## Summary
- expose the Cotizador Especial CCN root menu as an app entry by setting the app flag

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d199348ae483219cc936fff5cb6f64