### PR TITLE
Fix rubros internal data noupdate placement

### DIFF
--- a/data/rubros_internal.xml
+++ b/data/rubros_internal.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo noupdate="1">
-  <data>
+<odoo>
+  <data noupdate="1">
     <record id="rubro_admin" model="ccn.service.rubro">
       <field name="name">Administración (%)</field>
       <field name="sequence">990</field>


### PR DESCRIPTION
## Summary
- move the `noupdate` flag from the `<odoo>` root node to the `<data>` tag in `rubros_internal.xml`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d19c84098c8321931ef8dd83c01554