### PR TITLE
Fix invalid schema in menu XML

### DIFF
--- a/views/ccn_menus.xml
+++ b/views/ccn_menus.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-  <data>
+
     <!-- Menú raíz SIN acción -->
     <menuitem id="ccn_root_menu"
               name="Cotizador Especial CCN"
               sequence="20"
               app="True"/>
+
     <!-- Acción válida (la que corresponde a 478 si la tienes creada desde XML) -->
     <record id="ccn_action_quotes" model="ir.actions.act_window">
         <field name="name">Cotizaciones de Servicio</field>
@@ -14,9 +15,9 @@
     </record>
 
     <menuitem id="ccn_menu_quotes"
-            name="Cotizaciones de Servicio"
-            parent="ccn_root_menu"
-            action="ccn_service_quote.ccn_action_quotes"
-            sequence="10"/>
-  </data>
+              name="Cotizaciones de Servicio"
+              parent="ccn_root_menu"
+              action="ccn_service_quote.ccn_action_quotes"
+              sequence="10"/>
+
 </odoo>


### PR DESCRIPTION
## Summary
- remove the unnecessary <data> wrapper from the menu definition so it satisfies the XML schema validation during module loading

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d19df5f9d88321839611d93a6d2c30