### PR TITLE
Fix menu XML schema violation

### DIFF
--- a/views/ccn_menus.xml
+++ b/views/ccn_menus.xml
@@ -1,25 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data>
 
-        <!-- Menú raíz SIN acción -->
-        <menuitem id="ccn_root_menu"
-                  name="Cotizador Especial CCN"
-                  sequence="20"
-                  app="True"/>
+    <!-- Menú raíz SIN acción -->
+    <menuitem id="ccn_root_menu"
+              name="Cotizador Especial CCN"
+              sequence="20"
+              app="True"/>
 
-        <!-- Acción válida (la que corresponde a 478 si la tienes creada desde XML) -->
-        <record id="ccn_action_quotes" model="ir.actions.act_window">
-            <field name="name">Cotizaciones de Servicio</field>
-            <field name="res_model">ccn.service.quote</field>
-            <field name="view_mode">list,form</field>
-        </record>
+    <!-- Acción válida (la que corresponde a 478 si la tienes creada desde XML) -->
+    <record id="ccn_action_quotes" model="ir.actions.act_window">
+        <field name="name">Cotizaciones de Servicio</field>
+        <field name="res_model">ccn.service.quote</field>
+        <field name="view_mode">list,form</field>
+    </record>
 
-        <menuitem id="ccn_menu_quotes"
-                  name="Cotizaciones de Servicio"
-                  parent="ccn_root_menu"
-                  action="ccn_service_quote.ccn_action_quotes"
-                  sequence="10"/>
+    <menuitem id="ccn_menu_quotes"
+              name="Cotizaciones de Servicio"
+              parent="ccn_root_menu"
+              action="ccn_service_quote.ccn_action_quotes"
+              sequence="10"/>
 
-    </data>
 </odoo>


### PR DESCRIPTION
## Summary
- remove the <data> wrapper from `views/ccn_menus.xml` so the menu file matches the RelaxNG schema expected by Odoo
- keep the root menu, window action, and submenu definitions unchanged so they continue to load correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1a0f7ff3083218ef2cb20fbd4fb8c