### PR TITLE
Wrap menu items in data tag

### DIFF
--- a/views/ccn_menus.xml
+++ b/views/ccn_menus.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <!-- Menú raíz SIN acción -->
-    <menuitem id="ccn_root_menu"
-              name="Cotizador Especial CCN"
-              sequence="20"
-              app="True"/>
+    <data>
+        <!-- Menú raíz SIN acción -->
+        <menuitem id="ccn_root_menu"
+                  name="Cotizador Especial CCN"
+                  sequence="20"
+                  app="True"/>
 
-    <menuitem id="ccn_menu_quotes"
-              name="Cotizaciones de Servicio"
-              parent="ccn_root_menu"
-              action="ccn_service_quote.ccn_action_quotes"
-              sequence="10"/>
+        <menuitem id="ccn_menu_quotes"
+                  name="Cotizaciones de Servicio"
+                  parent="ccn_root_menu"
+                  action="ccn_service_quote.ccn_action_quotes"
+                  sequence="10"/>
+    </data>
 </odoo>


### PR DESCRIPTION
## Summary
- wrap the module menu definitions in a `<data>` element so the XML matches Odoo's schema requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1a68f9f7c8321b09dd8b90b5d5186