### PR TITLE
Fix menu XML schema for Odoo 17

### DIFF
--- a/views/ccn_menus.xml
+++ b/views/ccn_menus.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data>
-        <!-- Menú raíz SIN acción -->
-        <menuitem id="ccn_root_menu"
-                  name="Cotizador Especial CCN"
-                  sequence="20"
-                  app="True"/>
+    <!-- Menú raíz SIN acción -->
+    <menuitem id="ccn_root_menu"
+              name="Cotizador Especial CCN"
+              sequence="20"
+              app="True"/>
 
-        <menuitem id="ccn_menu_quotes"
-                  name="Cotizaciones de Servicio"
-                  parent="ccn_root_menu"
-                  action="ccn_service_quote.ccn_action_quotes"
-                  sequence="10"/>
-    </data>
+    <menuitem id="ccn_menu_quotes"
+              name="Cotizaciones de Servicio"
+              parent="ccn_root_menu"
+              action="ccn_service_quote.ccn_action_quotes"
+              sequence="10"/>
 </odoo>


### PR DESCRIPTION
## Summary
- remove the redundant <data> wrapper from the menu XML to match the Odoo 17 schema
- keep the Cotizador menu entries unchanged otherwise

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1a76825a08321aebd858012aa2ad2