### PR TITLE
Refactor menu action definitions

### DIFF
--- a/views/ccn_menus.xml
+++ b/views/ccn_menus.xml
@@ -1,25 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-  <data noupdate="0">
+  <!-- Menú raíz CCN -->
+  <menuitem id="menu_ccn_root" name="CCN" sequence="90"/>
 
-    <!-- Acción mínima para abrir ccn.service.quote -->
-    <record id="action_ccn_service_quote" model="ir.actions.act_window">
-      <field name="name">Cotizaciones</field>
-      <field name="res_model">ccn.service.quote</field>
-      <field name="view_mode">form</field>
-      <field name="context">{}</field>
-    </record>
-
-    <!-- Menú raíz CCN -->
-    <menuitem id="menu_ccn_root" name="CCN" sequence="90"/>
-
-    <!-- Submenú Cotizaciones que llama la acción anterior -->
-    <menuitem
-      id="menu_ccn_quotes"
-      name="Cotizaciones"
-      parent="menu_ccn_root"
-      action="action_ccn_service_quote"
-      sequence="10"/>
-
-  </data>
+  <!-- Submenú Cotizaciones que llama la acción anterior -->
+  <menuitem
+    id="menu_ccn_quotes"
+    name="Cotizaciones"
+    parent="menu_ccn_root"
+    action="ccn_service_quote.action_ccn_service_quote"
+    sequence="10"/>
 </odoo>

--- a/views/quote_actions.xml
+++ b/views/quote_actions.xml
@@ -9,5 +9,11 @@
       <field name="context">{}</field>
       <field name="domain">[]</field>
     </record>
+    <record id="action_ccn_service_quote" model="ir.actions.act_window">
+      <field name="name">Cotizaciones</field>
+      <field name="res_model">ccn.service.quote</field>
+      <field name="view_mode">form</field>
+      <field name="context">{}</field>
+    </record>
   </data>
 </odoo>


### PR DESCRIPTION
## Summary
- move the service quote action definition out of the menu XML into the dedicated actions file
- simplify the menu XML so it only declares menuitems and references the relocated action

## Testing
- `odoo-bin -u ccn_service_quote` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b2e4866c8321ac623f9b82c166b8