### PR TITLE
Place CCN menu under Sales root

### DIFF
--- a/views/ccn_menus.xml
+++ b/views/ccn_menus.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
   <!-- Menú raíz CCN -->
-  <menuitem id="menu_ccn_root" name="CCN" sequence="90"/>
+  <menuitem id="menu_ccn_root" name="CCN" parent="sale.menu_sale_root" sequence="90"/>
 
   <!-- Submenú Cotizaciones que llama la acción anterior -->
   <menuitem


### PR DESCRIPTION
## Summary
- attach the CCN root menu to the Sales top-level menu so the standard Apps entry is not displaced

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1b5c703b483218762a872a8875909