### PR TITLE
Fix CCN menu parent reference for Odoo 18

### DIFF
--- a/views/ccn_menus.xml
+++ b/views/ccn_menus.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
   <!-- Menú raíz CCN -->
-  <menuitem id="menu_ccn_root" name="CCN" parent="sale.menu_sale_root" sequence="90"/>
+  <menuitem id="menu_ccn_root" name="CCN" parent="sale.sale_menu_root" sequence="90"/>
 
   <!-- Submenú Cotizaciones que llama la acción anterior -->
   <menuitem


### PR DESCRIPTION
## Summary
- update the CCN root menu to inherit from the correct Odoo 18 Sales root menu ID

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1bfa9e74c83219c0358276f153785