### PR TITLE
Fix CCN app menu visibility

### DIFF
--- a/views/ccn_menus.xml
+++ b/views/ccn_menus.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
   <!-- Menú raíz CCN -->
-  <menuitem id="menu_ccn_root" name="CCN" parent="sale.sale_menu_root" sequence="90"/>
+  <menuitem
+    id="menu_ccn_root"
+    name="CCN"
+    sequence="90"
+    action="ccn_service_quote.ccn_action_quotes"
+    app="True"/>
 
-  <!-- Submenú Cotizaciones que llama la acción anterior -->
+  <!-- Submenú Cotizaciones -->
   <menuitem
     id="menu_ccn_quotes"
     name="Cotizaciones"
     parent="menu_ccn_root"
-    action="ccn_service_quote.action_ccn_service_quote"
+    action="ccn_service_quote.ccn_action_quotes"
     sequence="10"/>
 </odoo>


### PR DESCRIPTION
## Summary
- expose the CCN application from the app switcher by giving the root menu an action and enabling the app flag
- align the Cotizaciones submenu to reuse the list/form action for consistent navigation

## Testing
- not run (configuration-specific)


------
https://chatgpt.com/codex/tasks/task_e_68d1c2db5e2883218dad7282a5541824