### PR TITLE
Fix menu XML schema violation

### DIFF
--- a/views/ccn_menus.xml
+++ b/views/ccn_menus.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-  <data>
-    <!-- Menú raíz CCN -->
-    <menuitem
-      id="menu_ccn_root"
-      name="CCN"
-      sequence="90"
-      action="ccn_service_quote.ccn_action_quotes"
-      app="True"/>
+  <!-- Menú raíz CCN -->
+  <menuitem
+    id="menu_ccn_root"
+    name="CCN"
+    sequence="90"
+    action="ccn_service_quote.ccn_action_quotes"
+    app="True"/>
 
-    <!-- Submenú Cotizaciones -->
-    <menuitem
-      id="menu_ccn_quotes"
-      name="Cotizaciones"
-      parent="menu_ccn_root"
-      action="ccn_service_quote.ccn_action_quotes"
-      sequence="10"/>
-  </data>
+  <!-- Submenú Cotizaciones -->
+  <menuitem
+    id="menu_ccn_quotes"
+    name="Cotizaciones"
+    parent="menu_ccn_root"
+    action="ccn_service_quote.ccn_action_quotes"
+    sequence="10"/>
 </odoo>


### PR DESCRIPTION
## Summary
- restructure the menu XML by removing the unnecessary <data> wrapper
- ensure menu items are direct children of the <odoo> root to satisfy the schema validation

## Testing
- not run (schema-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d245a80b748321a5f344f0f6ad6249