### PR TITLE
Fix CCN menu XML schema compliance

### DIFF
--- a/views/ccn_menus.xml
+++ b/views/ccn_menus.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-  <data>
-    <!-- Menú raíz CCN -->
-    <menuitem
-      id="menu_ccn_root"
-      name="CCN"
-      sequence="90"
-      action="ccn_service_quote.ccn_action_quotes"
-      app="True"/>
+  <!-- Menú raíz CCN -->
+  <menuitem
+    id="menu_ccn_root"
+    name="CCN"
+    sequence="90"
+    action="ccn_service_quote.ccn_action_quotes"
+    app="True"/>
 
-    <!-- Submenú Cotizaciones -->
-    <menuitem
-      id="menu_ccn_quotes"
-      name="Cotizaciones"
-      parent="menu_ccn_root"
-      action="ccn_service_quote.ccn_action_quotes"
-      sequence="10"/>
-  </data>
+  <!-- Submenú Cotizaciones -->
+  <menuitem
+    id="menu_ccn_quotes"
+    name="Cotizaciones"
+    parent="menu_ccn_root"
+    action="ccn_service_quote.ccn_action_quotes"
+    sequence="10"/>
 </odoo>


### PR DESCRIPTION
## Summary
- remove the redundant <data> wrapper from the CCN menu XML definition to comply with the Odoo 18 schema

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d248bfac18832183dee3ce2759f512