### PR TITLE
Wrap menu XML in data container

### DIFF
--- a/views/ccn_menus.xml
+++ b/views/ccn_menus.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-  <!-- Menú raíz CCN -->
-  <menuitem
-    id="menu_ccn_root"
-    name="CCN"
-    sequence="90"
-    action="ccn_service_quote.ccn_action_quotes"
-    app="True"/>
+  <data>
+    <!-- Menú raíz CCN -->
+    <menuitem
+      id="menu_ccn_root"
+      name="CCN"
+      sequence="90"
+      action="ccn_service_quote.ccn_action_quotes"
+      app="True"/>
 
-  <!-- Submenú Cotizaciones -->
-  <menuitem
-    id="menu_ccn_quotes"
-    name="Cotizaciones"
-    parent="menu_ccn_root"
-    action="ccn_service_quote.ccn_action_quotes"
-    sequence="10"/>
+    <!-- Submenú Cotizaciones -->
+    <menuitem
+      id="menu_ccn_quotes"
+      name="Cotizaciones"
+      parent="menu_ccn_root"
+      action="ccn_service_quote.ccn_action_quotes"
+      sequence="10"/>
+  </data>
 </odoo>


### PR DESCRIPTION
## Summary
- wrap the CCN menu definitions in a <data> node so the XML matches Odoo's schema

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d250a6fbf0832181aeb7650698b1fa