### PR TITLE
Remove deprecated data wrappers from XML files

### DIFF
--- a/data/ccn_rubros.xml
+++ b/data/ccn_rubros.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
-  <data noupdate="1">
+<odoo noupdate="1">
 
     <!-- 1 -->
     <record id="ccn_rubro_mano_obra" model="ccn.service.rubro">
@@ -128,5 +127,4 @@
       <field name="apply_clean">1</field>
     </record>
 
-  </data>
 </odoo>

--- a/data/rubro_data.xml
+++ b/data/rubro_data.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo noupdate="1">
   <!-- No reescribas registros en upgrades -->
-  <data noupdate="1">
     <record id="rubro_mano_obra" model="ccn.service.rubro" forcecreate="0">
       <field name="code">mano_obra</field>
       <field name="name">Mano de Obra</field>
@@ -141,5 +140,4 @@
       <field name="internal_only">False</field>
       <field name="active">True</field>
     </record>
-  </data>
 </odoo>

--- a/data/rubros_internal.xml
+++ b/data/rubros_internal.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
-  <data noupdate="1">
+<odoo noupdate="1">
     <record id="rubro_admin" model="ccn.service.rubro">
       <field name="name">Administración (%)</field>
       <field name="sequence">990</field>
@@ -19,5 +18,4 @@
       <field name="internal_only">1</field>
       <field name="active">1</field>
     </record>
-  </data>
 </odoo>

--- a/views/ccn_menus.xml
+++ b/views/ccn_menus.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-  <data>
-    <!-- Menú raíz CCN -->
-    <menuitem
-      id="menu_ccn_root"
-      name="CCN"
-      sequence="90"
-      action="ccn_service_quote.ccn_action_quotes"
-      app="True"/>
+  <!-- Menú raíz CCN -->
+  <menuitem
+    id="menu_ccn_root"
+    name="CCN"
+    sequence="90"
+    action="ccn_service_quote.ccn_action_quotes"
+    app="True"/>
 
-    <!-- Submenú Cotizaciones -->
-    <menuitem
-      id="menu_ccn_quotes"
-      name="Cotizaciones"
-      parent="menu_ccn_root"
-      action="ccn_service_quote.ccn_action_quotes"
-      sequence="10"/>
-  </data>
+  <!-- Submenú Cotizaciones -->
+  <menuitem
+    id="menu_ccn_quotes"
+    name="Cotizaciones"
+    parent="menu_ccn_root"
+    action="ccn_service_quote.ccn_action_quotes"
+    sequence="10"/>
 </odoo>

--- a/views/ccn_quote_form_scope.xml
+++ b/views/ccn_quote_form_scope.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-  <data>
     <record id="view_ccn_service_quote_form_scope" model="ir.ui.view">
       <field name="name">ccn.service.quote.form.scope</field>
       <field name="model">ccn.service.quote</field>
@@ -11,5 +10,4 @@
         </xpath>
       </field>
     </record>
-  </data>
-</odoo>
+  </odoo>

--- a/views/ccn_quote_line_inline_product_domain.xml
+++ b/views/ccn_quote_line_inline_product_domain.xml
@@ -1,5 +1,4 @@
 <odoo>
-  <data>
     <!-- Para líneas que usan product.product -->
     <record id="view_ccn_quote_line_inline_product_domain" model="ir.ui.view">
       <field name="name">ccn.service.quote.line.inline.product.domain</field>
@@ -27,5 +26,4 @@
       </field>
     </record>
     -->
-  </data>
-</odoo>
+  </odoo>

--- a/views/cleanup_disable_legacy_views.xml
+++ b/views/cleanup_disable_legacy_views.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
-  <data noupdate="0">
+<odoo noupdate="0">
 
     <!-- Desactiva la vista heredada que metía los tabs de Sitio -->
     <record id="ccn_view_quote_form_tabs" model="ir.ui.view">
@@ -16,5 +15,4 @@
       </field>
     </record>
 
-  </data>
 </odoo>

--- a/views/pick_quote_wizard.xml
+++ b/views/pick_quote_wizard.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-  <data>
     <record id="view_pick_quote_wizard" model="ir.ui.view">
       <field name="name">ccn.pick.quote.wizard</field>
       <field name="model">ccn.service.quote.pick.wizard</field>
@@ -29,5 +28,4 @@
       <field name="view_mode">form</field>
       <field name="target">new</field>
     </record>
-  </data>
-</odoo>
+  </odoo>

--- a/views/product_template_ccn.xml
+++ b/views/product_template_ccn.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-  <data>
     <record id="ccn_product_template_form_inherit_rubros" model="ir.ui.view">
       <field name="name">product.template.form.ccn.rubros</field>
       <field name="model">product.template</field>
@@ -18,5 +17,4 @@
         </xpath>
       </field>
     </record>
-  </data>
-</odoo>
+  </odoo>

--- a/views/quote_actions.xml
+++ b/views/quote_actions.xml
@@ -1,19 +1,17 @@
 <odoo>
-  <data>
-    <!-- Acción de ventana para ccn.service.quote -->
-    <record id="ccn_action_quotes" model="ir.actions.act_window">
-      <field name="name">Cotizaciones de Servicio</field>
-      <field name="res_model">ccn.service.quote</field>
-      <!-- En v17/v18 usa 'list', no 'tree' -->
-      <field name="view_mode">list,form</field>
-      <field name="context">{}</field>
-      <field name="domain">[]</field>
-    </record>
-    <record id="action_ccn_service_quote" model="ir.actions.act_window">
-      <field name="name">Cotizaciones</field>
-      <field name="res_model">ccn.service.quote</field>
-      <field name="view_mode">form</field>
-      <field name="context">{}</field>
-    </record>
-  </data>
+  <!-- Acción de ventana para ccn.service.quote -->
+  <record id="ccn_action_quotes" model="ir.actions.act_window">
+    <field name="name">Cotizaciones de Servicio</field>
+    <field name="res_model">ccn.service.quote</field>
+    <!-- En v17/v18 usa 'list', no 'tree' -->
+    <field name="view_mode">list,form</field>
+    <field name="context">{}</field>
+    <field name="domain">[]</field>
+  </record>
+  <record id="action_ccn_service_quote" model="ir.actions.act_window">
+    <field name="name">Cotizaciones</field>
+    <field name="res_model">ccn.service.quote</field>
+    <field name="view_mode">form</field>
+    <field name="context">{}</field>
+  </record>
 </odoo>

--- a/views/quote_line_domain.xml
+++ b/views/quote_line_domain.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-  <data>
     <!-- Heredamos el FORM de la cotización para reemplazar la subvista de line_ids -->
     <record id="ccn_view_quote_form_filter_products" model="ir.ui.view">
       <field name="name">ccn.quote.form.filter.products</field>
@@ -48,5 +47,4 @@
 
       </field>
     </record>
-  </data>
-</odoo>
+  </odoo>

--- a/views/quote_line_list_inline.xml
+++ b/views/quote_line_list_inline.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-  <data>
     <record id="ccn_view_quote_line_list_inline" model="ir.ui.view">
       <field name="name">ccn.quote.line.list.inline</field>
       <field name="model">ccn.service.quote.line</field>
@@ -39,5 +38,4 @@
         </list>
       </field>
     </record>
-  </data>
-</odoo>
+  </odoo>

--- a/views/quote_line_tree_inline.xml
+++ b/views/quote_line_tree_inline.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-  <data>
     <record id="ccn_view_quote_line_tree_inline" model="ir.ui.view">
       <field name="name">ccn.quote.line.tree.inline</field>
       <field name="model">ccn.service.quote.line</field>
@@ -39,5 +38,4 @@
         </list>
       </field>
     </record>
-  </data>
-</odoo>
+  </odoo>

--- a/views/quote_site_fix.xml
+++ b/views/quote_site_fix.xml
@@ -1,6 +1,5 @@
 <!-- views/ccn_quote_site_fix.xml -->
 <odoo>
-  <data>
     <record id="view_ccn_service_quote_form_site_fix" model="ir.ui.view">
       <field name="name">ccn.service.quote.form.site.fix</field>
       <field name="model">ccn.service.quote</field>
@@ -13,5 +12,4 @@
         </xpath>
       </field>
     </record>
-  </data>
-</odoo>
+  </odoo>

--- a/views/quote_tabs_status.xml
+++ b/views/quote_tabs_status.xml
@@ -1,5 +1,4 @@
 <odoo>
-  <data>
     <record id="view_ccn_service_quote_form_tabs_status" model="ir.ui.view">
       <field name="name">ccn.service.quote.form.tabs.status</field>
       <field name="model">ccn.service.quote</field>
@@ -26,5 +25,4 @@
         </xpath>
       </field>
     </record>
-  </data>
-</odoo>
+  </odoo>

--- a/views/quote_views.xml
+++ b/views/quote_views.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-  <data>
 
     <record id="ccn_view_quote_form" model="ir.ui.view">
       <field name="name">ccn.quote.form</field>
@@ -382,5 +381,4 @@
       </field>
     </record>
 
-  </data>
-</odoo>
+  </odoo>

--- a/views/rubro_views.xml
+++ b/views/rubro_views.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-  <data>
 
     <record id="ccn_view_rubro_tree" model="ir.ui.view">
       <field name="name">ccn.rubro.tree</field>
@@ -38,5 +37,4 @@
       <field name="view_mode">list,form</field>
     </record>
 
-  </data>
-</odoo>
+  </odoo>

--- a/views/sale_order_button.xml
+++ b/views/sale_order_button.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-  <data>
     <record id="ccn_sale_order_button" model="ir.ui.view">
       <field name="name">ccn.sale.order.button</field>
       <field name="model">sale.order</field>
@@ -15,5 +14,4 @@
         </xpath>
       </field>
     </record>
-  </data>
-</odoo>
+  </odoo>

--- a/views/site_views.xml
+++ b/views/site_views.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-  <data>
 
     <!-- ================================
          FORM del modelo de Sitio (con indicadores ARRIBA)
@@ -169,5 +168,4 @@
       </field>
     </record>
 
-  </data>
-</odoo>
+  </odoo>

--- a/views/so_line_tree_ccn.xml
+++ b/views/so_line_tree_ccn.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-  <data>
 
     <!-- A) Subvista LIST para líneas de venta: 'name' primero -->
     <record id="ccn_sale_order_line_list_alt" model="ir.ui.view">
@@ -44,5 +43,4 @@
       </field>
     </record>
 
-  </data>
-</odoo>
+  </odoo>


### PR DESCRIPTION
## Summary
- remove deprecated <data> wrappers from all view and data XML files to satisfy the Odoo 18 schema
- move noupdate flags from <data> tags onto the root <odoo> elements while keeping existing records unchanged

## Testing
- not run (module changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d2527a026083218d9f42726c44192a