### PR TITLE
Fix menu XML schema

### DIFF
--- a/views/ccn_menus.xml
+++ b/views/ccn_menus.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-  <!-- Menú raíz CCN -->
-  <menuitem
-    id="menu_ccn_root"
-    name="CCN"
-    sequence="90"
-    action="ccn_service_quote.ccn_action_quotes"
-    app="True"/>
+  <data>
+    <!-- Menú raíz CCN -->
+    <menuitem
+      id="menu_ccn_root"
+      name="CCN"
+      sequence="90"
+      app="True"/>
 
-  <!-- Submenú Cotizaciones -->
-  <menuitem
-    id="menu_ccn_quotes"
-    name="Cotizaciones"
-    parent="menu_ccn_root"
-    action="ccn_service_quote.ccn_action_quotes"
-    sequence="10"/>
+    <!-- Submenú Cotizaciones -->
+    <menuitem
+      id="menu_ccn_quotes"
+      name="Cotizaciones"
+      parent="menu_ccn_root"
+      action="ccn_service_quote.ccn_action_quotes"
+      sequence="10"/>
+  </data>
 </odoo>


### PR DESCRIPTION
## Summary
- wrap module menu definitions in a <data> node to satisfy the Odoo XML schema
- remove the action from the root menu item so it behaves as an application entry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d25f9119148321a90bf579a01a8a29