### PR TITLE
Link service quotes to clients and enforce unique names

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -12,6 +12,7 @@ from . import (
     quote_line_related,
     quote_line_tax,
     quote_partner_user_fields,
+    res_partner,
     rubro,
     rubro_flag,
     sale_order,

--- a/models/quote_partner_user_fields.py
+++ b/models/quote_partner_user_fields.py
@@ -4,5 +4,5 @@ from odoo import fields, models
 class CCNServiceQuote(models.Model):
     _inherit = "ccn.service.quote"
 
-    partner_id = fields.Many2one("res.partner", string="Cliente")
+    partner_id = fields.Many2one("res.partner", string="Cliente", required=True)
     user_id = fields.Many2one("res.users", string="Responsable")

--- a/models/res_partner.py
+++ b/models/res_partner.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""Extensiones del modelo de clientes para cotizaciones de servicio."""
+
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    """Relaciona a cada cliente con sus cotizaciones de servicio."""
+
+    _inherit = "res.partner"
+
+    service_quote_ids = fields.One2many(
+        "ccn.service.quote",
+        "partner_id",
+        string="Cotizaciones de servicio",
+    )

--- a/models/service_quote.py
+++ b/models/service_quote.py
@@ -7,6 +7,13 @@ from odoo import api, fields, models, _
 class ServiceQuote(models.Model):
     _name = 'ccn.service.quote'
     _description = 'CCN Service Quote'
+    _sql_constraints = [
+        (
+            'ccn_service_quote_partner_name_uniq',
+            'unique(partner_id, name)',
+            'El nombre de la cotización debe ser único por cliente.',
+        )
+    ]
 
     name = fields.Char(string='Nombre', required=True, default=lambda self: _('Nueva Cotización'))
     currency_id = fields.Many2one(


### PR DESCRIPTION
## Summary
- enforce unique service quote names per cliente through an SQL constraint
- require associating each service quote with a cliente and expose the relation on res.partner
- register the partner extension model in the module registry

## Testing
- python -m compileall models

------
https://chatgpt.com/codex/tasks/task_e_68d4246e9dd08321812ce33ddb9fa7cf