### PR TITLE
Fix partner stat button modifiers for Odoo 17

### DIFF
--- a/views/res_partner_views.xml
+++ b/views/res_partner_views.xml
@@ -10,7 +10,7 @@
                   type="object"
                   class="oe_stat_button"
                   icon="fa-file-text-o"
-                  attrs="{'invisible': [('service_quote_count', '=', 0)]}">
+                  modifiers="{'invisible': [['service_quote_count', '=', 0]]}">
             <div class="o_stat_info">
               <span class="o_stat_value">
                 <field name="service_quote_count" widget="statinfo"/>


### PR DESCRIPTION
## Summary
- replace the deprecated `attrs` usage on the partner stat button with the supported `modifiers` attribute for Odoo 17

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d42eb2b924832184c90545a99ef380