### PR TITLE
Fix partner stat button modifiers for Odoo 17

### DIFF
--- a/views/res_partner_views.xml
+++ b/views/res_partner_views.xml
@@ -10,7 +10,7 @@
                   type="object"
                   class="oe_stat_button"
                   icon="fa-file-text-o"
-                  modifiers="{'invisible': [['service_quote_count', '=', 0]]}">
+                  modifiers='{"invisible": [["service_quote_count", "=", 0]]}'>
             <div class="o_stat_info">
               <span class="o_stat_value">
                 <field name="service_quote_count" widget="statinfo"/>


### PR DESCRIPTION
## Summary
- update the partner form stat button to use valid JSON modifiers syntax compatible with Odoo 17

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d42f8509f88321a20e469768e1a2fb