### PR TITLE
Set default site name to General

### DIFF
--- a/models/service_quote.py
+++ b/models/service_quote.py
@@ -216,7 +216,7 @@ class ServiceQuote(models.Model):
     def create(self, vals_list):
         for vals in vals_list:
             if not vals.get('site_ids'):
-                vals['site_ids'] = [(0, 0, {'name': _('Sitio Default')})]
+                vals['site_ids'] = [(0, 0, {'name': _('General')})]
         quotes = super().create(vals_list)
         for quote in quotes:
             if not quote.current_site_id and quote.site_ids:


### PR DESCRIPTION
## Summary
- update the service quote creation logic to create a default site named "General"
- keep the automatic selection of the first site as the current site when missing

## Testing
- python3 -m compileall models

------
https://chatgpt.com/codex/tasks/task_e_68d43532cb6c8321be7797ace20e28b5