### PR TITLE
Add default General site to new service quotes

### DIFF
--- a/models/service_quote.py
+++ b/models/service_quote.py
@@ -24,7 +24,16 @@ class ServiceQuote(models.Model):
     )
 
     # Sitios
-    site_ids = fields.One2many('ccn.service.quote.site', 'quote_id', string='Sitios')
+    def _default_site_ids(self):
+        """Provide a default "General" site when creating quotes."""
+        return [(0, 0, {"name": self.env._("General")})]
+
+    site_ids = fields.One2many(
+        "ccn.service.quote.site",
+        "quote_id",
+        string="Sitios",
+        default=_default_site_ids,
+    )
 
     # Modo de presentación
     display_mode = fields.Selection(


### PR DESCRIPTION
## Summary
- add an explicit default for the General site on service quote creation to ensure the initial site is always present

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d441124fb0832185558e2bc82953c1