### PR TITLE
Fix default General site initialization

### DIFF
--- a/models/service_quote.py
+++ b/models/service_quote.py
@@ -276,13 +276,6 @@ class ServiceQuote(models.Model):
                 quote.current_site_id = quote.site_ids[0].id
         return quotes
 
-    @api.model
-    def default_get(self, fields_list):
-        defaults = super().default_get(fields_list)
-        if not defaults.get('site_ids'):
-            defaults['site_ids'] = self._default_site_ids()
-        return defaults
-
     @api.onchange('current_service_type')
     def _onchange_current_service_type(self):
         for quote in self:


### PR DESCRIPTION
## Summary
- remove the legacy `default_get` override that reintroduced the old site default logic
- allow the new `default_get` implementation to prime `current_site_id` with the virtual "General" site so the selector is populated from the start

## Testing
- python -m compileall models

------
https://chatgpt.com/codex/tasks/task_e_68d44f81ad2c8321ba9b89fe20673b2b