### PR TITLE
Fix current site domain when no site records

### DIFF
--- a/views/quote_site_fix.xml
+++ b/views/quote_site_fix.xml
@@ -8,7 +8,7 @@
       <field name="arch" type="xml">
         <xpath expr="//field[@name='current_site_id']" position="replace">
           <field name="current_site_id"
-                 domain="[('id', 'in', site_ids.ids)]"
+                 domain="[('id', 'in', site_ids.ids if site_ids else [])]"
                  context="{'default_quote_id': id}"/>
         </xpath>
       </field>

--- a/views/quote_views.xml
+++ b/views/quote_views.xml
@@ -14,7 +14,7 @@
             <group>
               <field name="partner_id" required="1"/>
               <field name="name" colspan="2"/>
-              <field name="current_site_id" domain="[('id', 'in', site_ids.ids)]" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}" colspan="2"/>
+              <field name="current_site_id" domain="[('id', 'in', site_ids.ids if site_ids else [])]" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}" colspan="2"/>
               <field name="current_service_type" colspan="2"/>
               <field name="display_mode" colspan="2"/>
               <field name="admin_percent" colspan="2"/>

--- a/views/site_views.xml
+++ b/views/site_views.xml
@@ -75,7 +75,7 @@
           <group>
             <group string="Sitio en edición">
               <field name="current_site_id"
-                     domain="[('id', 'in', site_ids.ids)]"
+                     domain="[('id', 'in', site_ids.ids if site_ids else [])]"
                      context="{'default_quote_id': id}"/>
             </group>
             <group string="Sitios">
@@ -98,7 +98,7 @@
             <!-- A) Sitio actual (indicadores ARRIBA y líneas ABAJO, embebiendo el form del sitio) -->
             <page string="Sitio actual">
               <field name="current_site_id"
-                     domain="[('id', 'in', site_ids.ids)]"
+                     domain="[('id', 'in', site_ids.ids if site_ids else [])]"
                      context="{'default_quote_id': id}">
                 <!-- Reutilizamos el form del sitio -->
                 <form position="replace">


### PR DESCRIPTION
## Summary
- guard the current site selector's domain against empty site lists in all quote views

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d45c71fdcc83218a261aa7957cd56e