### PR TITLE
Fix default site domain

### DIFF
--- a/views/quote_views.xml
+++ b/views/quote_views.xml
@@ -14,7 +14,7 @@
             <group>
               <field name="partner_id" required="1"/>
               <field name="name" colspan="2"/>
-              <field name="current_site_id" domain="[('id', 'in', site_ids.ids if site_ids else [])]" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}" colspan="2"/>
+              <field name="current_site_id" domain="[('quote_id', 'in', [False, id])]" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}" colspan="2"/>
               <field name="current_service_type" colspan="2"/>
               <field name="display_mode" colspan="2"/>
               <field name="admin_percent" colspan="2"/>


### PR DESCRIPTION
## Summary
- allow the current site selector to include the in-memory default General site by filtering on the quote relation instead of the x2many ids

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d45e514e38832188b4bd4d18366f4c