### PR TITLE
Fix default General site domain

### DIFF
--- a/views/quote_site_fix.xml
+++ b/views/quote_site_fix.xml
@@ -8,7 +8,7 @@
       <field name="arch" type="xml">
         <xpath expr="//field[@name='current_site_id']" position="replace">
           <field name="current_site_id"
-                 domain="[('id', 'in', site_ids.ids if site_ids else [])]"
+                 domain="[('quote_id', 'in', [False, id])]"
                  context="{'default_quote_id': id}"/>
         </xpath>
       </field>

--- a/views/site_views.xml
+++ b/views/site_views.xml
@@ -75,7 +75,7 @@
           <group>
             <group string="Sitio en edición">
               <field name="current_site_id"
-                     domain="[('id', 'in', site_ids.ids if site_ids else [])]"
+                     domain="[('quote_id', 'in', [False, id])]"
                      context="{'default_quote_id': id}"/>
             </group>
             <group string="Sitios">
@@ -98,7 +98,7 @@
             <!-- A) Sitio actual (indicadores ARRIBA y líneas ABAJO, embebiendo el form del sitio) -->
             <page string="Sitio actual">
               <field name="current_site_id"
-                     domain="[('id', 'in', site_ids.ids if site_ids else [])]"
+                     domain="[('quote_id', 'in', [False, id])]"
                      context="{'default_quote_id': id}">
                 <!-- Reutilizamos el form del sitio -->
                 <form position="replace">


### PR DESCRIPTION
## Summary
- allow the in-form site selector to keep showing the unsaved "General" site by relaxing its domain
- apply the same domain fix on the patch view that also replaces the selector

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d45fa779108321b42d12b1988d7d5d